### PR TITLE
feat(api): support metadata-driven previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,39 @@
-# 📸 Social Preview Generator
+# Social Preview Generator
 
-> Generate beautiful social media preview images from any URL
+Generate Open Graph/social preview images from URLs or known page metadata.
 
 [![npm version](https://img.shields.io/npm/v/@nanggo/social-preview.svg)](https://www.npmjs.com/package/@nanggo/social-preview)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js CI](https://github.com/nanggo/social-preview-generator/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/nanggo/social-preview-generator/actions/workflows/npm-publish.yml)
 
-## ✨ Features
+## Features
 
-- 🔍 **Automatic Metadata Extraction** - Extracts Open Graph and Twitter Card metadata from any URL
-- 🎨 **Beautiful Templates** - Modern, customizable templates for stunning previews
-- 🖼️ **Smart Image Processing** - Automatically processes and optimizes images
-- 🔄 **Intelligent Fallbacks** - Generates attractive previews even when metadata is missing
-- ⚡ **High Performance** - Built with Sharp for blazing-fast image processing
-- 🎯 **TypeScript Support** - Full TypeScript support with comprehensive type definitions
-- 🌏 **Korean Language Support** - Optimized for Korean text rendering
+- Extract Open Graph and Twitter Card metadata from a URL
+- Generate images directly from supplied metadata for static publishing flows
+- Render with built-in `modern`, `classic`, and `minimal` templates
+- Process and optimize images with Sharp
+- Fall back to generated previews when metadata is incomplete
+- Ship TypeScript definitions
+- Support Korean text rendering
 
-## 📦 Installation
+## Installation
 
 ```bash
 npm install @nanggo/social-preview
 ```
 
-## 🚀 Quick Start
+## Quick Start
 
 ```javascript
 const { generatePreview } = require('@nanggo/social-preview');
 
-// Simple usage
 const imageBuffer = await generatePreview('https://github.com');
 
-// Save to file
 const fs = require('fs').promises;
 await fs.writeFile('preview.jpg', imageBuffer);
 ```
 
-## 📖 API
+## API
 
 ### `generatePreview(url, options?)`
 
@@ -50,29 +48,71 @@ Generates a social preview image from a URL.
 
 - `Promise<Buffer>`: Image buffer in JPEG format
 
+### `generatePreviewFromMetadata(metadata, options?)`
+
+Generates a social preview image from metadata you already have. It does not fetch or scrape the
+page URL, which makes it useful for static blog publishing pipelines where title, description,
+canonical URL, and cover image are known at publish/build time.
+
+#### Parameters
+
+- `metadata` (PreviewMetadataInput): Page or post metadata to render
+- `options` (PreviewOptions): Optional configuration
+
+#### Returns
+
+- `Promise<Buffer>`: Image buffer in JPEG format
+
 ### Options
 
 ```typescript
 interface PreviewOptions {
-  template?: 'modern' | 'classic' | 'minimal';  // Template to use (default: 'modern')
-  width?: number;                                // Image width (default: 1200)
-  height?: number;                               // Image height (default: 630)
-  quality?: number;                              // JPEG quality 1-100 (default: 90)
-  cache?: boolean;                               // Cache generated results in memory (default: false)
+  template?: 'modern' | 'classic' | 'minimal'; // Template to use (default: 'modern')
+  width?: number; // Image width (default: 1200)
+  height?: number; // Image height (default: 630)
+  quality?: number; // JPEG quality 1-100 (default: 90)
+  cache?: boolean; // Cache generated results in memory (default: false)
   fallback?: {
-    strategy?: 'auto' | 'custom' | 'generate';   // Fallback strategy
-    image?: string;                               // Custom fallback image path
-    text?: string;                                // Custom fallback text
+    strategy?: 'auto' | 'custom' | 'generate'; // Fallback strategy
+    image?: string; // Custom fallback image path
+    text?: string; // Custom fallback text
   };
   colors?: {
-    background?: string;                          // Background color
-    text?: string;                                // Text color
-    accent?: string;                              // Accent color
+    background?: string; // Background color
+    text?: string; // Text color
+    accent?: string; // Accent color
   };
 }
 ```
 
-## 💡 Examples
+### Static Blog Publishing
+
+Generate the image once while publishing a post, then point `og:image` at the written file.
+
+```javascript
+const { generatePreviewFromMetadata } = require('@nanggo/social-preview');
+const fs = require('fs').promises;
+
+const buffer = await generatePreviewFromMetadata(
+  {
+    title: 'How to Generate Open Graph Images',
+    description: 'Create a social preview image while publishing a blog post.',
+    siteName: 'My Blog',
+    url: 'https://example.com/posts/open-graph-images',
+    image: 'https://example.com/images/open-graph-cover.jpg',
+  },
+  {
+    template: 'modern',
+    width: 1200,
+    height: 630,
+    quality: 90,
+  }
+);
+
+await fs.writeFile('public/og/open-graph-images.jpg', buffer);
+```
+
+## Examples
 
 ### Basic Usage
 
@@ -93,9 +133,9 @@ const buffer = await generatePreview('https://example.com', {
   colors: {
     background: '#2c3e50',
     accent: '#3498db',
-    text: '#ffffff'
+    text: '#ffffff',
   },
-  quality: 95
+  quality: 95,
 });
 ```
 
@@ -105,30 +145,33 @@ const buffer = await generatePreview('https://example.com', {
 const buffer = await generatePreview('https://example.com', {
   fallback: {
     strategy: 'generate',
-    text: 'My Custom Preview'
-  }
+    text: 'My Custom Preview',
+  },
 });
 ```
 
-## 🎨 Templates
+## Templates
 
 ### Modern (Default)
+
 - Clean, contemporary design
 - Gradient overlays
 - Centered text layout
 - Perfect for tech and modern websites
 
 ### Classic
+
 - Traditional card layout
 - Image on top, text below
 - Great for news and blog sites
 
 ### Minimal
+
 - Simple, text-focused design
 - Minimal decorations
 - Ideal for documentation sites
 
-## 🏗️ Architecture
+## Architecture
 
 ```
 social-preview-generator/
@@ -151,7 +194,7 @@ social-preview-generator/
 │   └── index.ts                         # Main entry point
 ```
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
@@ -161,17 +204,17 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-## 📄 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
 - [Sharp](https://sharp.pixelplumbing.com/) - High performance image processing
 - [Open Graph Scraper](https://github.com/jshemas/openGraphScraper) - Metadata extraction
 - [Axios](https://axios-http.com/) - HTTP client
 
-## 🔗 Links
+## Links
 
 - [npm Package](https://www.npmjs.com/package/@nanggo/social-preview)
 - [GitHub Repository](https://github.com/nanggo/social-preview-generator)
@@ -179,4 +222,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-Made with ❤️ by [nanggo](https://github.com/nanggo)
+Made by [nanggo](https://github.com/nanggo)

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,5 +1,6 @@
 export {
   PreviewOptions,
+  PreviewMetadataInput,
   ExtractedMetadata,
   GeneratedPreview,
   TemplateConfig,
@@ -12,4 +13,3 @@ export { startCacheCleanup, stopCacheCleanup, isCacheCleanupRunning } from './ut
 export { getInflightRequestStats, clearInflightRequests } from './core/metadata-extractor';
 
 export { getCacheStats, clearAllCaches, shutdownSharpCaches } from './utils/sharp-cache';
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 
 import {
   PreviewOptions,
+  PreviewMetadataInput,
   SanitizedOptions,
   ExtractedMetadata,
   GeneratedPreview,
@@ -15,7 +16,12 @@ import {
 import { extractMetadata, validateMetadata, applyFallbacks } from './core/metadata-extractor';
 import { createFallbackImage, DEFAULT_DIMENSIONS } from './core/image-generator';
 import { templates } from './templates/registry';
-import { validateDimensions, sanitizeOptions } from './utils/validators';
+import {
+  validateDimensions,
+  sanitizeOptions,
+  sanitizeControlChars,
+  validateUrlInput,
+} from './utils/validators';
 import { initializeSharpSecurity } from './utils/image-security';
 import { generateDefaultOverlay } from './core/overlay-generator';
 import { processImageForTemplate } from './core/template-image-processing';
@@ -33,6 +39,114 @@ export * from './exports';
 
 const FALLBACK_PREVIEW_CACHE_TTL_MS = 30_000;
 
+function createFinalOptions(options: PreviewOptions = {}): SanitizedOptions {
+  return sanitizeOptions({
+    template: 'modern',
+    width: DEFAULT_DIMENSIONS.width,
+    height: DEFAULT_DIMENSIONS.height,
+    quality: 90,
+    cache: false,
+    ...options,
+  });
+}
+
+function getTemplate(templateName: SanitizedOptions['template']): TemplateConfig {
+  const template = templates[templateName || 'modern'];
+
+  if (!template) {
+    throw new PreviewGeneratorError(
+      ErrorType.TEMPLATE_ERROR,
+      `Template "${templateName}" not found`
+    );
+  }
+
+  return template;
+}
+
+function createPreviewResult(
+  buffer: Buffer,
+  metadata: ExtractedMetadata,
+  finalOptions: SanitizedOptions
+): GeneratedPreview {
+  return {
+    buffer,
+    format: 'jpeg',
+    dimensions: {
+      width: finalOptions.width || DEFAULT_DIMENSIONS.width,
+      height: finalOptions.height || DEFAULT_DIMENSIONS.height,
+    },
+    metadata,
+    template: finalOptions.template || 'modern',
+    cached: false,
+  };
+}
+
+function normalizeOptionalMetadataText(
+  value: string | undefined,
+  fieldName: string
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, `${fieldName} must be a string`);
+  }
+
+  const normalized = sanitizeControlChars(value)
+    .replace(/[\n\r]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return normalized || undefined;
+}
+
+function normalizeRequiredMetadataText(value: string | undefined, fieldName: string): string {
+  const normalized = normalizeOptionalMetadataText(value, fieldName);
+
+  if (!normalized) {
+    throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, `${fieldName} is required`);
+  }
+
+  return normalized;
+}
+
+function normalizeMetadataInput(metadata: PreviewMetadataInput): ExtractedMetadata {
+  const url = validateUrlInput(metadata.url);
+  const urlObj = new URL(url);
+  const title = normalizeRequiredMetadataText(metadata.title, 'metadata.title');
+
+  return {
+    title,
+    description: normalizeOptionalMetadataText(metadata.description, 'metadata.description'),
+    image: metadata.image ? validateUrlInput(metadata.image) : undefined,
+    siteName:
+      normalizeOptionalMetadataText(metadata.siteName, 'metadata.siteName') ||
+      urlObj.hostname.replace('www.', ''),
+    favicon: metadata.favicon
+      ? validateUrlInput(metadata.favicon)
+      : `${urlObj.protocol}//${urlObj.hostname}/favicon.ico`,
+    author: normalizeOptionalMetadataText(metadata.author, 'metadata.author'),
+    publishedDate: normalizeOptionalMetadataText(metadata.publishedDate, 'metadata.publishedDate'),
+    url,
+    domain: normalizeOptionalMetadataText(metadata.domain, 'metadata.domain') || urlObj.hostname,
+    locale: normalizeOptionalMetadataText(metadata.locale, 'metadata.locale') || 'en_US',
+  };
+}
+
+function createMetadataPreviewCacheKey(metadata: ExtractedMetadata): string {
+  return `metadata:${JSON.stringify(metadata)}`;
+}
+
+async function renderPreviewFromMetadata(
+  metadata: ExtractedMetadata,
+  finalOptions: SanitizedOptions
+): Promise<GeneratedPreview> {
+  const template = getTemplate(finalOptions.template);
+  const buffer = await generateImageWithSanitizedOptions(metadata, template, finalOptions);
+  return createPreviewResult(buffer, metadata, finalOptions);
+}
+
 /**
  * Generate a social preview image from a URL
  * @param url - The URL to generate preview for
@@ -41,6 +155,21 @@ const FALLBACK_PREVIEW_CACHE_TTL_MS = 30_000;
  */
 export async function generatePreview(url: string, options: PreviewOptions = {}): Promise<Buffer> {
   const result = await generatePreviewWithDetails(url, options);
+  return result.buffer;
+}
+
+/**
+ * Generate a social preview image from caller-provided metadata.
+ * Use this for static/publish-time blog preview generation when metadata is already known.
+ * @param metadata - Post/page metadata to render
+ * @param options - Configuration options
+ * @returns Buffer containing the generated image
+ */
+export async function generatePreviewFromMetadata(
+  metadata: PreviewMetadataInput,
+  options: PreviewOptions = {}
+): Promise<Buffer> {
+  const result = await generatePreviewFromMetadataWithDetails(metadata, options);
   return result.buffer;
 }
 
@@ -71,15 +200,33 @@ async function generateImageWithSanitizedOptions(
   try {
     validateDimensions(width, height);
 
-    const baseImage = await processImageForTemplate(metadata, template, width, height, sanitizedOptions);
+    const baseImage = await processImageForTemplate(
+      metadata,
+      template,
+      width,
+      height,
+      sanitizedOptions
+    );
 
     let overlayBuffer: Buffer;
 
     if (template.overlayGenerator) {
-      const overlaySvg = template.overlayGenerator(metadata, width, height, sanitizedOptions, template);
+      const overlaySvg = template.overlayGenerator(
+        metadata,
+        width,
+        height,
+        sanitizedOptions,
+        template
+      );
       overlayBuffer = svgCache.getCachedSVG(overlaySvg) ?? svgCache.cacheSVG(overlaySvg);
     } else {
-      overlayBuffer = await generateDefaultOverlay(metadata, template, width, height, sanitizedOptions);
+      overlayBuffer = await generateDefaultOverlay(
+        metadata,
+        template,
+        width,
+        height,
+        sanitizedOptions
+      );
     }
 
     const finalImage = await baseImage
@@ -93,7 +240,7 @@ async function generateImageWithSanitizedOptions(
       .jpeg({
         quality,
         progressive: true,
-        mozjpeg: true
+        mozjpeg: true,
       })
       .toBuffer();
 
@@ -120,15 +267,7 @@ export async function generatePreviewWithDetails(
       startCacheCleanup();
     }
 
-    // Merge defaults then validate+sanitize in a single pass
-    const finalOptions = sanitizeOptions({
-      template: 'modern',
-      width: DEFAULT_DIMENSIONS.width,
-      height: DEFAULT_DIMENSIONS.height,
-      quality: 90,
-      cache: false,
-      ...options,
-    });
+    const finalOptions = createFinalOptions(options);
 
     const shouldCache = finalOptions.cache === true;
     if (shouldCache) {
@@ -176,35 +315,7 @@ export async function generatePreviewWithDetails(
       throw error;
     }
 
-    // Get template configuration
-    const templateName = finalOptions.template || 'modern';
-    const template = templates[templateName];
-
-    if (!template) {
-      throw new PreviewGeneratorError(
-        ErrorType.TEMPLATE_ERROR,
-        `Template "${templateName}" not found`
-      );
-    }
-
-    // Generate image based on template - use pre-sanitized options with defaults applied
-    const buffer = await generateImageWithSanitizedOptions(
-      metadata,
-      template,
-      finalOptions
-    );
-
-    const result: GeneratedPreview = {
-      buffer,
-      format: 'jpeg',
-      dimensions: {
-        width: finalOptions.width || DEFAULT_DIMENSIONS.width,
-        height: finalOptions.height || DEFAULT_DIMENSIONS.height,
-      },
-      metadata,
-      template: finalOptions.template || 'modern',
-      cached: false,
-    };
+    const result = await renderPreviewFromMetadata(metadata, finalOptions);
     if (shouldCache) {
       setCachedPreview(url, finalOptions, result);
     }
@@ -216,6 +327,48 @@ export async function generatePreviewWithDetails(
     throw new PreviewGeneratorError(
       ErrorType.IMAGE_ERROR,
       `Failed to generate preview with details for ${url}: ${error instanceof Error ? error.message : String(error)}`,
+      error
+    );
+  }
+}
+
+/**
+ * Generate a preview from caller-provided metadata with full result details.
+ */
+export async function generatePreviewFromMetadataWithDetails(
+  metadataInput: PreviewMetadataInput,
+  options: PreviewOptions = {}
+): Promise<GeneratedPreview> {
+  try {
+    // Lazily start cache cleanup on first actual usage (not at import time)
+    if (!isCacheCleanupRunning()) {
+      startCacheCleanup();
+    }
+
+    const finalOptions = createFinalOptions(options);
+    const metadata = normalizeMetadataInput(metadataInput);
+
+    const shouldCache = finalOptions.cache === true;
+    const cacheKey = createMetadataPreviewCacheKey(metadata);
+    if (shouldCache) {
+      const cached = getCachedPreview(cacheKey, finalOptions);
+      if (cached) {
+        return { ...cached, cached: true };
+      }
+    }
+
+    const result = await renderPreviewFromMetadata(metadata, finalOptions);
+    if (shouldCache) {
+      setCachedPreview(cacheKey, finalOptions, result);
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof PreviewGeneratorError) {
+      throw error;
+    }
+    throw new PreviewGeneratorError(
+      ErrorType.IMAGE_ERROR,
+      `Failed to generate preview from metadata: ${error instanceof Error ? error.message : String(error)}`,
       error
     );
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,16 @@ export interface PreviewOptions {
 }
 
 /**
+ * Metadata supplied directly by the caller for static/publish-time preview generation.
+ */
+export interface PreviewMetadataInput extends Partial<ExtractedMetadata> {
+  /** Page or post title */
+  title: string;
+  /** Canonical URL for the page or post */
+  url: string;
+}
+
+/**
  * Security configuration options
  */
 export interface SecurityOptions {

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -1,5 +1,12 @@
 import { vi } from 'vitest';
-import { clearAllCaches, clearInflightRequests, generatePreview, generatePreviewWithDetails } from '../../src/index';
+import {
+  clearAllCaches,
+  clearInflightRequests,
+  generatePreview,
+  generatePreviewFromMetadata,
+  generatePreviewFromMetadataWithDetails,
+  generatePreviewWithDetails,
+} from '../../src/index';
 import { PreviewOptions } from '../../src/types';
 import axios from 'axios';
 import ogs from 'open-graph-scraper';
@@ -32,7 +39,7 @@ describe('End-to-End Integration Tests', () => {
     clearAllCaches();
     clearInflightRequests();
     metadataCache.clear();
-    
+
     // Setup default mocks
     const mockSharpInstance = {
       resize: vi.fn().mockReturnThis(),
@@ -41,11 +48,12 @@ describe('End-to-End Integration Tests', () => {
       composite: vi.fn().mockReturnThis(),
       jpeg: vi.fn().mockReturnThis(),
       png: vi.fn().mockReturnThis(),
+      metadata: vi.fn().mockResolvedValue({ width: 1200, height: 630, format: 'png' }),
       toBuffer: vi.fn().mockResolvedValue(Buffer.from('generated-image')),
     };
 
     mockedSharp.mockReturnValue(mockSharpInstance as any);
-    
+
     // Setup default axios response
     mockedAxios.get.mockResolvedValue({
       data: `
@@ -79,7 +87,7 @@ describe('End-to-End Integration Tests', () => {
   describe('generatePreview', () => {
     it('should generate preview image successfully', async () => {
       const url = 'https://example.com';
-      
+
       const result = await generatePreview(url);
 
       expect(result).toBeInstanceOf(Buffer);
@@ -111,12 +119,12 @@ describe('End-to-End Integration Tests', () => {
       const result = await generatePreview(url, options);
 
       expect(result).toBeInstanceOf(Buffer);
-      
+
       const sharpInstance = mockedSharp.mock.results[0].value;
-      expect(sharpInstance.jpeg).toHaveBeenCalledWith({ 
+      expect(sharpInstance.jpeg).toHaveBeenCalledWith({
         quality: 85,
         progressive: true,
-        mozjpeg: true 
+        mozjpeg: true,
       });
     });
 
@@ -181,9 +189,9 @@ describe('End-to-End Integration Tests', () => {
     it('should generate modern template successfully', async () => {
       const url = 'https://example.com';
       const options: PreviewOptions = { template: 'modern' };
-      
+
       const result = await generatePreview(url, options);
-      
+
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(10);
     });
@@ -191,9 +199,9 @@ describe('End-to-End Integration Tests', () => {
     it('should generate classic template successfully', async () => {
       const url = 'https://example.com';
       const options: PreviewOptions = { template: 'classic' };
-      
+
       const result = await generatePreview(url, options);
-      
+
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(10);
     });
@@ -201,19 +209,19 @@ describe('End-to-End Integration Tests', () => {
     it('should generate minimal template successfully', async () => {
       const url = 'https://example.com';
       const options: PreviewOptions = { template: 'minimal' };
-      
+
       const result = await generatePreview(url, options);
-      
+
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(10);
     });
 
     it('should handle template-specific color options', async () => {
       const url = 'https://example.com';
-      
+
       // Test each template with custom colors
       const templates: Array<'modern' | 'classic' | 'minimal'> = ['modern', 'classic', 'minimal'];
-      
+
       for (const template of templates) {
         const options: PreviewOptions = {
           template,
@@ -223,9 +231,9 @@ describe('End-to-End Integration Tests', () => {
             background: '#f5f5f5',
           },
         };
-        
+
         const result = await generatePreview(url, options);
-        
+
         expect(result).toBeInstanceOf(Buffer);
         expect(result.length).toBeGreaterThan(10);
       }
@@ -233,13 +241,15 @@ describe('End-to-End Integration Tests', () => {
 
     it('should handle long content across all templates', async () => {
       const url = 'https://example.com';
-      
+
       // Mock long content metadata for all template iterations
       mockedOgs.mockResolvedValue({
         error: false,
         result: {
-          ogTitle: 'This is an extremely long title that should be properly handled by all template types with appropriate wrapping and truncation',
-          ogDescription: 'This is a very long description that contains a lot of text and should be properly wrapped and truncated according to each template\'s specific design requirements and text handling capabilities',
+          ogTitle:
+            'This is an extremely long title that should be properly handled by all template types with appropriate wrapping and truncation',
+          ogDescription:
+            "This is a very long description that contains a lot of text and should be properly wrapped and truncated according to each template's specific design requirements and text handling capabilities",
           ogSiteName: 'Very Long Site Name That Might Need Truncation',
         },
         html: '<html></html>',
@@ -247,10 +257,10 @@ describe('End-to-End Integration Tests', () => {
       });
 
       const templates: Array<'modern' | 'classic' | 'minimal'> = ['modern', 'classic', 'minimal'];
-      
+
       for (const template of templates) {
         const result = await generatePreview(url, { template });
-        
+
         expect(result).toBeInstanceOf(Buffer);
         expect(result.length).toBeGreaterThan(10);
       }
@@ -282,6 +292,122 @@ describe('End-to-End Integration Tests', () => {
         template: 'modern',
         cached: false,
       });
+    });
+  });
+
+  describe('generatePreviewFromMetadata', () => {
+    it('should generate preview image without fetching page metadata', async () => {
+      const result = await generatePreviewFromMetadata(
+        {
+          title: 'Static Blog Post',
+          description: 'Generated while publishing the post.',
+          siteName: 'Example Blog',
+          url: 'https://blog.example.com/posts/static-blog-post',
+        },
+        {
+          template: 'minimal',
+          width: 800,
+          height: 420,
+        }
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(mockedOgs).not.toHaveBeenCalled();
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(mockedSharp).toHaveBeenCalled();
+    });
+
+    it('should return detailed preview information from direct metadata', async () => {
+      const result = await generatePreviewFromMetadataWithDetails(
+        {
+          title: 'Direct Metadata Post',
+          description: 'No crawler required.',
+          url: 'https://blog.example.com/posts/direct-metadata-post',
+        },
+        {
+          template: 'classic',
+          width: 1000,
+          height: 525,
+        }
+      );
+
+      expect(result).toMatchObject({
+        buffer: expect.any(Buffer),
+        format: 'jpeg',
+        dimensions: {
+          width: 1000,
+          height: 525,
+        },
+        metadata: expect.objectContaining({
+          title: 'Direct Metadata Post',
+          description: 'No crawler required.',
+          url: 'https://blog.example.com/posts/direct-metadata-post',
+          domain: 'blog.example.com',
+          siteName: 'blog.example.com',
+        }),
+        template: 'classic',
+        cached: false,
+      });
+      expect(mockedOgs).not.toHaveBeenCalled();
+    });
+
+    it('should fetch direct metadata image without scraping page metadata', async () => {
+      const pngImageBuffer = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+        'base64'
+      );
+      mockedAxios.get.mockResolvedValueOnce({
+        data: pngImageBuffer,
+        headers: {
+          'content-type': 'image/png',
+        },
+      });
+
+      const result = await generatePreviewFromMetadata({
+        title: 'Post With Cover Image',
+        description: 'Use the cover image as the preview background.',
+        siteName: 'Example Blog',
+        url: 'https://blog.example.com/posts/with-cover',
+        image: 'https://cdn.example.com/covers/with-cover.png',
+      });
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(mockedOgs).not.toHaveBeenCalled();
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://cdn.example.com/covers/with-cover.png',
+        expect.objectContaining({
+          responseType: 'arraybuffer',
+          headers: expect.objectContaining({
+            'User-Agent': 'Mozilla/5.0 (compatible; SocialPreviewBot/1.0)',
+          }),
+        })
+      );
+      expect(mockedSharp).toHaveBeenCalledWith(pngImageBuffer, expect.any(Object));
+    });
+
+    it('should cache direct metadata previews by metadata content', async () => {
+      const metadata = {
+        title: 'Cached Static Post',
+        description: 'Generated once during publishing.',
+        url: 'https://blog.example.com/posts/cached-static-post',
+      };
+
+      const first = await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
+      const second = await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
+
+      expect(first.cached).toBe(false);
+      expect(second.cached).toBe(true);
+      expect(second.buffer).toBeInstanceOf(Buffer);
+    });
+
+    it('should reject invalid canonical URLs', async () => {
+      await expect(
+        generatePreviewFromMetadata({
+          title: 'Invalid URL Post',
+          url: 'not-a-url',
+        })
+      ).rejects.toThrow();
     });
   });
 
@@ -327,17 +453,13 @@ describe('End-to-End Integration Tests', () => {
     });
 
     it('should handle multiple concurrent requests', async () => {
-      const urls = [
-        'https://example1.com',
-        'https://example2.com',
-        'https://example3.com',
-      ];
+      const urls = ['https://example1.com', 'https://example2.com', 'https://example3.com'];
 
-      const promises = urls.map(url => generatePreview(url));
+      const promises = urls.map((url) => generatePreview(url));
       const results = await Promise.all(promises);
 
       expect(results).toHaveLength(3);
-      results.forEach(result => {
+      results.forEach((result) => {
         expect(result).toBeInstanceOf(Buffer);
       });
     });


### PR DESCRIPTION
## What changed

- Added `generatePreviewFromMetadata()` and `generatePreviewFromMetadataWithDetails()` for static/publish-time preview generation from caller-provided metadata.
- Added `PreviewMetadataInput` and exported it from the package type surface.
- Reused the existing template/image rendering pipeline so URL-based generation keeps the same behavior.
- Added integration coverage for metadata-only generation, detailed results, cache behavior, invalid canonical URLs, and direct metadata image fetching without page scraping.
- Reworked the README wording to describe URL-based and metadata-based usage more directly.

## Why

For blog publishing workflows, title, description, canonical URL, and cover image are already known when a post is published. Generating the OG image from that metadata avoids runtime scraping and makes it possible to write a static image file during publication.

## Validation

- `pnpm run lint`
- `pnpm run build`
- `SKIP_NETWORK_TESTS=true pnpm test`
- `pnpm exec prettier --check README.md src/index.ts src/types/index.ts src/exports.ts test/integration/end-to-end.test.ts`
- `git diff --check`
- `npm_config_cache=/private/tmp/npm-cache-social-preview npm pack --dry-run`