### PR TITLE
fix: harden preview rendering and packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22', '24']
+        node-version: ['22.13.0', '24']
 
     steps:
       - name: Checkout
@@ -90,3 +90,6 @@ jobs:
 
       - name: Verify package contents
         run: npm pack --dry-run
+
+      - name: Verify production package import
+        run: pnpm run verify:package

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Generate Open Graph/social preview images from URLs or known page metadata.
 
 ## Installation
 
+Requires Node.js 22.13+ (22.x) or 24+.
+
 ```bash
 npm install @nanggo/social-preview
 ```

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run",
     "lint": "eslint src",
     "format": "prettier --write 'src/**/*.ts'",
+    "verify:package": "node scripts/verify-packed-package.mjs",
     "prepublishOnly": "pnpm run build && pnpm test"
   },
   "keywords": [
@@ -43,12 +44,13 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "dependencies": {
     "axios": "^1.11.0",
-    "dompurify": "^3.2.6",
+    "dompurify": "^3.4.11",
     "file-type": "^22.0.1",
+    "jsdom": "^29.1.1",
     "open-graph-scraper": "^6.10.0",
     "sharp": "^0.35.1"
   },
@@ -66,7 +68,6 @@
     "@typescript-eslint/parser": "^8.39.0",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.2",
-    "jsdom": "^29.1.1",
     "parse5": "^8.0.0",
     "prettier": "^3.6.2",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,14 @@ importers:
         specifier: ^1.11.0
         version: 1.18.0
       dompurify:
-        specifier: ^3.2.6
-        version: 3.4.10
+        specifier: ^3.4.11
+        version: 3.4.11
       file-type:
         specifier: ^22.0.1
         version: 22.0.1
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       open-graph-scraper:
         specifier: ^6.10.0
         version: 6.11.0
@@ -45,9 +48,6 @@ importers:
       eslint:
         specifier: ^10.0.2
         version: 10.5.0
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
       parse5:
         specifier: ^8.0.0
         version: 8.0.1
@@ -908,8 +908,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -1447,12 +1447,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   uri-js@4.4.1:
@@ -2248,7 +2244,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.22.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   combined-stream@1.0.8:
@@ -2309,7 +2305,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -2626,7 +2622,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -2705,7 +2701,7 @@ snapshots:
       chardet: 2.1.1
       cheerio: 1.2.0
       iconv-lite: 0.7.2
-      undici: 7.22.0
+      undici: 7.28.0
 
   optionator@0.9.4:
     dependencies:
@@ -2919,9 +2915,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.22.0: {}
-
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'social-preview-package-smoke-'));
+const consumerDirectory = join(temporaryRoot, 'consumer');
+const npmCacheDirectory = join(temporaryRoot, 'npm-cache');
+
+try {
+  const packOutput = execFileSync(
+    'npm',
+    ['pack', '--json', '--pack-destination', temporaryRoot, '--cache', npmCacheDirectory],
+    { encoding: 'utf8' }
+  );
+  const packResult = JSON.parse(packOutput);
+  const packageFilename = packResult[0]?.filename;
+
+  if (!packageFilename) {
+    throw new Error('npm pack did not return a package filename');
+  }
+
+  mkdirSync(consumerDirectory);
+  execFileSync(
+    'npm',
+    [
+      'install',
+      '--prefix',
+      consumerDirectory,
+      '--omit=dev',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--cache',
+      npmCacheDirectory,
+      join(temporaryRoot, basename(packageFilename)),
+    ],
+    { stdio: 'inherit' }
+  );
+
+  const requireFromConsumer = createRequire(join(consumerDirectory, 'package.json'));
+  const packageExports = requireFromConsumer('@nanggo/social-preview');
+
+  if (typeof packageExports.generatePreview !== 'function') {
+    throw new Error('Packed package did not expose generatePreview');
+  }
+
+  console.log('Packed package imported successfully from a production-only install.');
+} finally {
+  rmSync(temporaryRoot, { force: true, recursive: true });
+}

--- a/src/constants/security.ts
+++ b/src/constants/security.ts
@@ -272,8 +272,9 @@ export const FORBIDDEN_SVG_ATTRIBUTES = [
   'clip-path', 'mask', 'filter',
 ] as const;
 
-/** Allowed SVG URI pattern (only fragment identifiers) */
-export const ALLOWED_SVG_URI_PATTERN = /^#/;
+/** Allow non-URI SVG values and local url(#fragment) references, but no external resources */
+export const ALLOWED_SVG_URI_PATTERN =
+  /^(?!.*(?:[a-z][a-z0-9+.-]*:|\/\/|url\(\s*(?!['"]?#)))[\s\S]*$/i;
 
 /** Allowed SVG namespaces */
 export const ALLOWED_SVG_NAMESPACES = ['http://www.w3.org/2000/svg'] as const;

--- a/src/constants/security.ts
+++ b/src/constants/security.ts
@@ -274,7 +274,7 @@ export const FORBIDDEN_SVG_ATTRIBUTES = [
 
 /** Allow non-URI SVG values and local url(#fragment) references, but no external resources */
 export const ALLOWED_SVG_URI_PATTERN =
-  /^(?!.*(?:[a-z][a-z0-9+.-]*:|\/\/|url\(\s*(?!['"]?#)))[\s\S]*$/i;
+  /^(?![\s\S]*(?:[a-z][a-z0-9+.-]*:|\/\/|url\(\s*(?!['"]?#)))[\s\S]*$/i;
 
 /** Allowed SVG namespaces */
 export const ALLOWED_SVG_NAMESPACES = ['http://www.w3.org/2000/svg'] as const;

--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -507,10 +507,11 @@ export async function fetchImage(imageUrl: string, securityOptions?: SecurityOpt
       );
     }
 
-    // Validate image for security (pixel bombs, malformed files, etc.)
-    await validateImageBuffer(imageBuffer, securityOptions?.allowSvg);
+    // Validate image for security (pixel bombs, malformed files, etc.).
+    // SVG validation returns DOMPurify-cleaned bytes; raster bytes remain unchanged.
+    const validatedImageBuffer = await validateImageBuffer(imageBuffer, securityOptions?.allowSvg);
 
-    return imageBuffer;
+    return validatedImageBuffer;
   } catch (error) {
     throw new PreviewGeneratorError(
       ErrorType.IMAGE_ERROR,

--- a/src/utils/image-security.ts
+++ b/src/utils/image-security.ts
@@ -34,6 +34,13 @@ import {
 
 type AllowedImageFormat = typeof ALLOWED_IMAGE_FORMATS extends Set<infer T> ? T : never;
 
+// DOMPurify applies ALLOWED_URI_REGEXP to every attribute that is not marked URI-safe.
+// Preserve ordinary SVG geometry/text values while keeping paint attributes subject to
+// the external-reference policy because fill and stroke may contain url(...) values.
+const NON_URI_SVG_ATTRIBUTES = ALLOWED_SVG_ATTRIBUTES.filter(
+  attribute => attribute !== 'fill' && attribute !== 'stroke'
+);
+
 interface FileTypeResult {
   readonly ext: string;
   readonly mime: string;
@@ -96,12 +103,13 @@ export function initializeSharpSecurity(): void {
 }
 
 /**
- * Validate image buffer before processing
+ * Validate image buffer before processing and return the safe bytes to process.
+ * SVG input may be sanitized, while raster input is returned unchanged.
  */
 export async function validateImageBuffer(
   imageBuffer: Buffer,
   allowSvg: boolean = false
-): Promise<void> {
+): Promise<Buffer> {
   // Check file size
   if (imageBuffer.length > MAX_FILE_SIZE) {
     throw new PreviewGeneratorError(
@@ -114,8 +122,7 @@ export async function validateImageBuffer(
   const isSvgCandidate =
     allowSvg && imageBuffer.toString('utf8', 0, 512).toLowerCase().includes('<svg');
   if (isSvgCandidate) {
-    await validateSvgContent(imageBuffer);
-    return; // Skip Sharp validation for SVG
+    return validateSvgContent(imageBuffer); // Skip Sharp validation for SVG
   }
 
   // Hybrid validation: try file-type first, fallback to magic bytes
@@ -178,6 +185,8 @@ export async function validateImageBuffer(
       `Invalid or corrupted image file: ${error instanceof Error ? error.message : String(error)}`
     );
   }
+
+  return imageBuffer;
 }
 
 /**
@@ -254,9 +263,9 @@ async function validateImageFormat(imageBuffer: Buffer): Promise<void> {
 }
 
 /**
- * Validate SVG content for security risks using DOMPurify
+ * Validate SVG content for security risks using DOMPurify and return cleaned bytes
  */
-export async function validateSvgContent(svgBuffer: Buffer): Promise<void> {
+export async function validateSvgContent(svgBuffer: Buffer): Promise<Buffer> {
   const svgContent = svgBuffer.toString('utf8');
 
   // Check SVG size limits first
@@ -276,7 +285,8 @@ export async function validateSvgContent(svgBuffer: Buffer): Promise<void> {
       USE_PROFILES: { svg: true, svgFilters: true },
       ALLOWED_TAGS: [...ALLOWED_SVG_TAGS],
       ALLOWED_ATTR: [...ALLOWED_SVG_ATTRIBUTES],
-      // Only allow fragment identifiers (internal document links), no external URIs
+      ADD_URI_SAFE_ATTR: [...NON_URI_SVG_ATTRIBUTES],
+      // Allow colors and local fragment references, but no external resources
       ALLOWED_URI_REGEXP: ALLOWED_SVG_URI_PATTERN,
       
       // Explicitly forbid dangerous tags (in addition to not allowing them)
@@ -370,6 +380,8 @@ export async function validateSvgContent(svgBuffer: Buffer): Promise<void> {
         'SVG validation failed: content does not appear to be a valid SVG after sanitization'
       );
     }
+
+    return Buffer.from(cleanSvg, 'utf8');
   } catch (error) {
     if (error instanceof PreviewGeneratorError) {
       throw error;
@@ -396,6 +408,7 @@ export function sanitizeSvgContent(svgContent: string): string {
       USE_PROFILES: { svg: true, svgFilters: true },
       ALLOWED_TAGS: [...ALLOWED_SVG_TAGS],
       ALLOWED_ATTR: [...ALLOWED_SVG_ATTRIBUTES],
+      ADD_URI_SAFE_ATTR: [...NON_URI_SVG_ATTRIBUTES],
       ALLOWED_URI_REGEXP: ALLOWED_SVG_URI_PATTERN,
       FORBID_TAGS: [...FORBIDDEN_SVG_TAGS],
       FORBID_ATTR: [...FORBIDDEN_SVG_ATTRIBUTES],

--- a/src/utils/sharp-cache.ts
+++ b/src/utils/sharp-cache.ts
@@ -18,6 +18,14 @@ import crypto from 'crypto';
 import { SHARP_SECURITY_CONFIG } from '../constants/security';
 import { logger } from './logger';
 
+// Generated SVGs declare their dimensions in CSS pixels. Sharp's default SVG
+// density preserves those dimensions, while the higher density used to inspect
+// untrusted external images scales generated canvases and overlays up.
+const GENERATED_SVG_SHARP_CONFIG = {
+  ...SHARP_SECURITY_CONFIG,
+  density: 72,
+};
+
 interface CacheEntry<T> {
   value: T;
   createdAt: number;
@@ -238,7 +246,7 @@ class CanvasCache extends SharpLRUCache<string> {
     const cachedSvg = this.get(key);
     
     // Create fresh Sharp instance from cached SVG content
-    return cachedSvg ? sharp(Buffer.from(cachedSvg), SHARP_SECURITY_CONFIG) : undefined;
+    return cachedSvg ? sharp(Buffer.from(cachedSvg), GENERATED_SVG_SHARP_CONFIG) : undefined;
   }
 
   cacheCanvas(width: number, height: number, options: CanvasOptions, svgContent: string): void {
@@ -282,7 +290,7 @@ export async function createCachedSVG(svgContent: string): Promise<sharp.Sharp> 
   }
 
   // Create Sharp instance from cached buffer
-  return sharp(buffer, SHARP_SECURITY_CONFIG);
+  return sharp(buffer, GENERATED_SVG_SHARP_CONFIG);
 }
 
 /**
@@ -319,7 +327,7 @@ export async function createCachedCanvas(
     // Cache miss - create canvas and cache the SVG content
     const svgContent = createCanvasSVG(width, height, options);
     canvasCache.cacheCanvas(width, height, options, svgContent);
-    canvas = sharp(Buffer.from(svgContent), SHARP_SECURITY_CONFIG);
+    canvas = sharp(Buffer.from(svgContent), GENERATED_SVG_SHARP_CONFIG);
     logger?.debug?.('Canvas cache miss - cached new canvas SVG');
   } else {
     logger?.debug?.('Canvas cache hit');

--- a/test/integration/render-dimensions.test.ts
+++ b/test/integration/render-dimensions.test.ts
@@ -1,0 +1,82 @@
+import sharp from 'sharp';
+import { generateImageWithTemplate, generatePreviewFromMetadata } from '../../src/index';
+import type { ExtractedMetadata, TemplateConfig } from '../../src/types';
+
+const directMetadata: ExtractedMetadata = {
+  title: 'Render dimensions',
+  description: 'Generated without a remote background image.',
+  siteName: 'Example',
+  url: 'https://example.com/render-dimensions',
+};
+
+async function expectImageDimensions(buffer: Buffer, width: number, height: number): Promise<void> {
+  const metadata = await sharp(buffer).metadata();
+
+  expect(metadata.width).toBe(width);
+  expect(metadata.height).toBe(height);
+}
+
+describe('generated image dimensions with real Sharp', () => {
+  it.each([
+    { width: 320, height: 168 },
+    { width: 1200, height: 630 },
+  ])('renders a modern no-image preview at $width x $height', async ({ width, height }) => {
+    const buffer = await generatePreviewFromMetadata(directMetadata, {
+      template: 'modern',
+      width,
+      height,
+    });
+
+    await expectImageDimensions(buffer, width, height);
+  });
+
+  it.each(['classic', 'minimal'] as const)(
+    'keeps the %s template at the requested dimensions',
+    async (template) => {
+      const width = 320;
+      const height = 168;
+      const buffer = await generatePreviewFromMetadata(directMetadata, {
+        template,
+        width,
+        height,
+      });
+
+      await expectImageDimensions(buffer, width, height);
+    }
+  );
+
+  it('renders a custom template through the default overlay at the requested dimensions', async () => {
+    const width = 320;
+    const height = 168;
+    const customTemplate: TemplateConfig = {
+      name: 'custom-default-overlay',
+      layout: {
+        padding: 24,
+        imagePosition: 'none',
+      },
+      typography: {
+        title: {
+          fontSize: 32,
+          fontWeight: '700',
+          lineHeight: 1.2,
+          maxLines: 2,
+        },
+        description: {
+          fontSize: 18,
+          lineHeight: 1.3,
+          maxLines: 2,
+        },
+      },
+      imageProcessing: {
+        requiresTransparentCanvas: true,
+      },
+    };
+
+    const buffer = await generateImageWithTemplate(directMetadata, customTemplate, {
+      width,
+      height,
+    });
+
+    await expectImageDimensions(buffer, width, height);
+  });
+});

--- a/test/unit/fetch-image-svg-sanitization.test.ts
+++ b/test/unit/fetch-image-svg-sanitization.test.ts
@@ -1,0 +1,137 @@
+import { vi } from 'vitest';
+import axios from 'axios';
+import sharp from 'sharp';
+import { fetchImage } from '../../src/core/metadata-extractor';
+
+vi.mock('axios');
+vi.mock('../../src/utils/enhanced-secure-agent', () => ({
+  getEnhancedSecureAgentForUrl: vi.fn(() => undefined),
+  validateRequestSecurity: vi.fn().mockResolvedValue({
+    allowed: true,
+    blockedIPs: [],
+    allowedIPs: [],
+  }),
+}));
+
+const mockedAxios = vi.mocked(axios);
+const imageUrl = 'https://example.com/preview.svg';
+
+async function fetchSvg(svg: string): Promise<Buffer> {
+  mockedAxios.get.mockResolvedValueOnce({
+    data: Buffer.from(svg),
+    headers: { 'content-type': 'image/svg+xml' },
+  });
+
+  return fetchImage(imageUrl, { allowSvg: true });
+}
+
+describe('fetchImage SVG sanitization boundary', () => {
+  beforeEach(() => {
+    mockedAxios.get.mockReset();
+  });
+
+  it('returns cleaned SVG bytes after removing forbidden elements and external references', async () => {
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+        <style>@import url("https://attacker.example/styles.css");</style>
+        <foreignObject width="10" height="10">
+          <div xmlns="http://www.w3.org/1999/xhtml">untrusted HTML</div>
+        </foreignObject>
+        <rect id="safe-shape" width="10" height="10" fill="#00f"
+          filter="url(https://example.com/f.svg#x)" />
+      </svg>
+    `;
+
+    const result = (await fetchSvg(svg)).toString('utf8');
+
+    expect(result).toContain('<svg');
+    expect(result).toContain('id="safe-shape"');
+    expect(result).toContain('fill="#00f"');
+    expect(result).not.toMatch(/<style|@import|<foreignObject|untrusted HTML/i);
+    expect(result).not.toContain('filter=');
+    expect(result).not.toContain('https://example.com/f.svg#x');
+  });
+
+  it.each([
+    [
+      'paint-server URL',
+      '<rect width="10" height="10" fill="url(https://example.com/f.svg#x)"/>',
+      'fill=',
+    ],
+    [
+      'file URL',
+      '<rect width="10" height="10" clip-path="url(file:///etc/passwd)"/>',
+      'clip-path=',
+    ],
+    [
+      'protocol-relative URL',
+      '<rect width="10" height="10" stroke="url(//attacker.example/stroke.svg#x)"/>',
+      'stroke=',
+    ],
+    ['data URL', '<rect width="10" height="10" fill="data:image/svg+xml,external"/>', 'fill='],
+  ])('strips an alternate external %s payload', async (_name, element, attribute) => {
+    const result = (
+      await fetchSvg(`<svg xmlns="http://www.w3.org/2000/svg">${element}</svg>`)
+    ).toString('utf8');
+
+    expect(result).toContain('<rect');
+    expect(result).not.toContain(attribute);
+    expect(result).not.toMatch(
+      /https:\/\/example\.com\/f\.svg#x|file:\/\/\/etc\/passwd|attacker\.example|data:image/
+    );
+  });
+
+  it('preserves legitimate SVG elements and attributes', async () => {
+    const svg = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="120" height="60" viewBox="0 0 120 60">
+        <defs>
+          <linearGradient id="brand-gradient" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0" stop-color="#123456"/>
+            <stop offset="1" stop-color="#abcdef"/>
+          </linearGradient>
+        </defs>
+        <rect id="background" width="120" height="60"
+          fill="url('#brand-gradient')" stroke="black" stroke-width="2"/>
+        <text x="10" y="35" font-size="20" fill="red">Safe preview</text>
+      </svg>
+    `;
+
+    const result = (await fetchSvg(svg)).toString('utf8');
+
+    expect(result).toContain('<linearGradient');
+    expect(result).toContain('id="brand-gradient"');
+    expect(result).toContain('id="background"');
+    expect(result).toContain('Safe preview');
+    expect(result).toContain('viewBox="0 0 120 60"');
+    expect(result).toContain('fill="url(\'#brand-gradient\')"');
+    expect(result).toContain('stroke="black"');
+    expect(result).toContain('fill="red"');
+
+    const renderedMetadata = await sharp(Buffer.from(result)).metadata();
+    expect(renderedMetadata.format).toBe('svg');
+    expect(renderedMetadata.width).toBe(120);
+    expect(renderedMetadata.height).toBe(60);
+  });
+
+  it('returns raster bytes unchanged', async () => {
+    const png = await sharp({
+      create: {
+        width: 2,
+        height: 2,
+        channels: 4,
+        background: { r: 12, g: 34, b: 56, alpha: 1 },
+      },
+    })
+      .png()
+      .toBuffer();
+
+    mockedAxios.get.mockResolvedValueOnce({
+      data: png,
+      headers: { 'content-type': 'image/png' },
+    });
+
+    const result = await fetchImage('https://example.com/preview.png', { allowSvg: true });
+
+    expect(result).toEqual(png);
+  });
+});

--- a/test/unit/fetch-image-svg-sanitization.test.ts
+++ b/test/unit/fetch-image-svg-sanitization.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 import axios from 'axios';
 import sharp from 'sharp';
+import { ALLOWED_SVG_URI_PATTERN } from '../../src/constants/security';
 import { fetchImage } from '../../src/core/metadata-extractor';
 
 vi.mock('axios');
@@ -15,6 +16,12 @@ vi.mock('../../src/utils/enhanced-secure-agent', () => ({
 
 const mockedAxios = vi.mocked(axios);
 const imageUrl = 'https://example.com/preview.svg';
+
+describe('SVG URI policy', () => {
+  it('rejects an external reference after a line terminator', () => {
+    expect(ALLOWED_SVG_URI_PATTERN.test('\nurl(https://attacker.example/fill.svg#x)')).toBe(false);
+  });
+});
 
 async function fetchSvg(svg: string): Promise<Buffer> {
   mockedAxios.get.mockResolvedValueOnce({
@@ -67,6 +74,11 @@ describe('fetchImage SVG sanitization boundary', () => {
       'protocol-relative URL',
       '<rect width="10" height="10" stroke="url(//attacker.example/stroke.svg#x)"/>',
       'stroke=',
+    ],
+    [
+      'newline-prefixed external URL',
+      '<rect width="10" height="10" fill="&#10;url(https://attacker.example/fill.svg#x)"/>',
+      'fill=',
     ],
     ['data URL', '<rect width="10" height="10" fill="data:image/svg+xml,external"/>', 'fill='],
   ])('strips an alternate external %s payload', async (_name, element, attribute) => {

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -25,8 +25,8 @@ const mockedImageSecurity = imageSecurity as vi.Mocked<typeof imageSecurity>;
 describe('Metadata Extractor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock validateImageBuffer to resolve successfully for tests
-    mockedImageSecurity.validateImageBuffer = vi.fn().mockResolvedValue(undefined);
+    // Mock validateImageBuffer to return the validated bytes unchanged for these tests
+    mockedImageSecurity.validateImageBuffer = vi.fn().mockImplementation(async imageBuffer => imageBuffer);
   });
 
   describe('extractMetadata', () => {


### PR DESCRIPTION
## What

- preserve requested dimensions for generated SVG canvases and overlays
- return and render DOMPurify-sanitized SVG bytes while leaving raster bytes unchanged
- ship `jsdom` as a runtime dependency and verify the packed package from a production-only install
- align the Node.js engine/CI matrix and update DOMPurify/Undici to patched versions
- add real-Sharp dimension coverage and SVG sanitization boundary tests

## Why

The current package can upscale generated no-image previews because internal SVGs use the external-image density, discard sanitized SVG output before rendering, and fail when installed without dev dependencies because `jsdom` is imported at runtime.

## Validation

- `pnpm exec vitest run test/integration/render-dimensions.test.ts test/unit/fetch-image-svg-sanitization.test.ts` (12 passed)
- `pnpm test` (333 passed)
- `pnpm exec tsc -p test/tsconfig.json --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run verify:package`
- `npm pack --dry-run --cache /private/tmp/social-preview-npm-cache`
- `pnpm audit --prod` (no known vulnerabilities)
- representative 1200x630 output inspected at the requested pixel dimensions
