### PR TITLE
docs: update repository working agreements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,16 @@
-# Repository Guidelines
+# social-preview-generator Working Agreements
 
-## Project Structure & Module Organization
-`src/` contains the TypeScript library code (entrypoint `src/index.ts`):
-- `src/core/` metadata extraction + image generation pipeline
-- `src/templates/` OG image templates (`modern.ts`, `classic.ts`, `minimal.ts`) and shared helpers (`shared.ts`, `registry.ts`)
-- `src/utils/` shared helpers (including `src/utils/validators/`)
-- `src/constants/`, `src/types/` shared limits and public types
-- `src/assets/` static assets (fallback images/fonts when present)
+This repository is a TypeScript library that generates social-preview images from URLs or caller-provided metadata.
 
-Tests live in `test/` (`unit/`, `integration/`, `performance/`) with fixtures in `test/fixtures/`; Vitest is configured in `vitest.config.ts`. `examples/` contains runnable demos/middleware. Generated artifacts like `dist/`, `coverage/`, and `examples/output/` are gitignored.
+## Runtime and Public Surface
 
-## Build, Test, and Development Commands
-- `pnpm install` install dependencies (requires Node `>=20`)
-- `pnpm run build` compile to `dist/` with `tsc`
-- `pnpm run dev` run `tsc --watch`
-- `pnpm test` run Vitest
-- `pnpm run lint` lint `src/**/*.ts` with ESLint (`eslint.config.mjs`)
-- `pnpm run format` format `src/**/*.ts` with Prettier
-- `cd examples && pnpm install && pnpm start` run the example server (optional)
+- Use `pnpm`; `package.json#packageManager` and `package.json#engines` are the current pnpm and Node source of truth.
+- Library code lives under `src/`; `pnpm run build` compiles it to the ignored `dist/` directory.
+- The public surface includes `src/index.ts`, `src/exports.ts`, `src/types/`, and `package.json#exports`. Preserve compatibility across these boundaries unless the current request explicitly authorizes an API change.
 
-## Coding Style & Naming Conventions
-- TypeScript is `strict`; avoid `any` where practical (`@typescript-eslint/no-explicit-any` is a warning in source, off in tests).
-- Prettier settings: 2 spaces, single quotes, semicolons, `printWidth: 100` (see `.prettierrc`).
-- Naming: files in `kebab-case.ts`; functions/vars `camelCase`; types/classes `PascalCase`; constants `SCREAMING_SNAKE_CASE`.
+## Verification
 
-## Testing Guidelines
-- Place tests as `*.test.ts` / `*.spec.ts` under `test/**` (or `src/**/__tests__/**`).
-- Some integration tests may hit the network; use `SKIP_NETWORK_TESTS=true pnpm test` where supported (see `test/integration/real-urls.test.ts`).
-- For visual/template changes, include a before/after sample image in the PR description (do not commit large binaries).
-
-## Commit & Pull Request Guidelines
-- Use Conventional Commits (`feat(security): …`, `fix(validation): …`, `perf(optimization): …`).
-- PRs should include: what/why, linked issue (if any), test + lint status, and any relevant sample outputs.
+- Start with the closest Vitest file, then run `pnpm test`. The default suite excludes the real-URL HTTP test, but some `enhanced-secure-agent` unit cases still exercise system DNS, so do not assume it is fully network-free.
+- `test/integration/real-urls.test.ts` is excluded by `vitest.config.ts` and performs real network requests. Do not include it in ordinary validation; run it only when the request explicitly calls for real-URL behavior.
+- Add `pnpm run lint` for source changes and `pnpm run build` for public exports, types, or packaging changes.
+- For template or rendering changes, generate representative images under ignored `examples/output/` or a temporary directory and inspect the actual pixels and dimensions. Do not treat a passing unit test alone as visual verification, and do not commit generated `dist/`, coverage, or sample-image artifacts.


### PR DESCRIPTION
## What

- replace stale generic repository notes with focused working agreements for this package
- point runtime and package-manager guidance to `package.json` as the source of truth
- document the public API boundaries that require compatibility care
- clarify ordinary, real-network, and visual verification expectations

## Why

The previous guidance included an outdated Node.js requirement and implied a network-test workflow that does not match the current Vitest configuration. The revised document keeps repository automation aligned with the actual package contract.

## Validation

- docs-only change
- `git diff --check`
