### PR TITLE
fix(ssrf): disable implicit proxies and harden redirects

### DIFF
--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -5,9 +5,13 @@
 
 import ogs from 'open-graph-scraper';
 import axios from 'axios';
-import { ExtractedMetadata, ErrorType, PreviewGeneratorError, SecurityOptions, RedirectOptions } from '../types';
+import { ExtractedMetadata, ErrorType, PreviewGeneratorError, SecurityOptions } from '../types';
 import { validateUrlInput } from '../utils/validators';
-import { getEnhancedSecureAgentForUrl, validateRequestSecurity } from '../utils/enhanced-secure-agent';
+import {
+  getEnhancedSecureHttpAgent,
+  getEnhancedSecureHttpsAgent,
+  validateRequestSecurity,
+} from '../utils/enhanced-secure-agent';
 import { validateImageBuffer } from '../utils/image-security';
 import { metadataCache } from '../utils/cache';
 import { logger } from '../utils/logger';
@@ -29,22 +33,34 @@ const MAX_IMAGE_SIZE = 15 * 1024 * 1024;
 /**
  * Build redirect validation callback for SSRF protection
  */
-function createRedirectValidator(context: string) {
+function createRedirectValidator(context: string, httpsOnly: boolean = false) {
   return (
     options: Record<string, unknown>,
     _responseDetails: { headers: Record<string, string>; statusCode: number }
   ) => {
-    const redirectOptions = options as unknown as RedirectOptions;
-    const redirectUrl = `${redirectOptions.protocol}//${redirectOptions.hostname}${
-      redirectOptions.port ? `:${redirectOptions.port}` : ''
-    }${redirectOptions.path || ''}${redirectOptions.search || ''}`;
+    if (typeof options.href !== 'string' || options.href.length === 0) {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        `${context} blocked: canonical redirect URL is missing`
+      );
+    }
+
+    const redirectUrl = options.href;
+    let validatedRedirectUrl: string;
     try {
-      validateUrlInput(redirectUrl);
+      validatedRedirectUrl = validateUrlInput(redirectUrl);
     } catch (error) {
       throw new PreviewGeneratorError(
         ErrorType.VALIDATION_ERROR,
         `${context} to unsafe URL blocked: ${redirectUrl}`,
         error
+      );
+    }
+
+    if (httpsOnly && new URL(validatedRedirectUrl).protocol !== 'https:') {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        `${context} blocked by HTTPS-only mode: ${validatedRedirectUrl}`
       );
     }
   };
@@ -304,10 +320,11 @@ async function fetchOpenGraphData(url: string, securityOptions?: SecurityOptions
     maxRedirects: securityOptions?.maxRedirects ?? 3,
     maxContentLength: 1 * 1024 * 1024,
     maxBodyLength: 1 * 1024 * 1024,
-    httpAgent: getEnhancedSecureAgentForUrl(url),
-    httpsAgent: getEnhancedSecureAgentForUrl(url),
+    httpAgent: getEnhancedSecureHttpAgent(),
+    httpsAgent: getEnhancedSecureHttpsAgent(),
+    proxy: false as const,
     signal: abortSignal,
-    beforeRedirect: createRedirectValidator('Redirect'),
+    beforeRedirect: createRedirectValidator('Redirect', securityOptions?.httpsOnly === true),
   };
 
   // Phase 1: Fetch HTML through secure agent
@@ -474,10 +491,14 @@ export async function fetchImage(imageUrl: string, securityOptions?: SecurityOpt
       maxRedirects: securityOptions?.maxRedirects ?? 3, // Configurable redirects
       maxContentLength: MAX_IMAGE_SIZE,
       maxBodyLength: MAX_IMAGE_SIZE,
-      httpAgent: getEnhancedSecureAgentForUrl(validatedUrl),
-      httpsAgent: getEnhancedSecureAgentForUrl(validatedUrl),
+      httpAgent: getEnhancedSecureHttpAgent(),
+      httpsAgent: getEnhancedSecureHttpsAgent(),
+      proxy: false,
       signal: abortSignal, // Add abort signal for request cancellation
-      beforeRedirect: createRedirectValidator('Image redirect'),
+      beforeRedirect: createRedirectValidator(
+        'Image redirect',
+        securityOptions?.httpsOnly === true
+      ),
     });
 
     // Check content-type header if available (extract base MIME type, ignoring charset etc.)

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -18,6 +18,8 @@ vi.mock('open-graph-scraper');
 vi.mock('sharp');
 vi.mock('../../src/utils/enhanced-secure-agent', () => ({
   getEnhancedSecureAgentForUrl: vi.fn(() => undefined),
+  getEnhancedSecureHttpAgent: vi.fn(() => undefined),
+  getEnhancedSecureHttpsAgent: vi.fn(() => undefined),
   validateRequestSecurity: vi.fn().mockResolvedValue({
     allowed: true,
     blockedIPs: [],

--- a/test/performance/cache-performance.test.ts
+++ b/test/performance/cache-performance.test.ts
@@ -15,6 +15,8 @@ vi.mock('open-graph-scraper');
 vi.mock('sharp');
 vi.mock('../../src/utils/enhanced-secure-agent', () => ({
   getEnhancedSecureAgentForUrl: vi.fn(() => undefined),
+  getEnhancedSecureHttpAgent: vi.fn(() => undefined),
+  getEnhancedSecureHttpsAgent: vi.fn(() => undefined),
   validateRequestSecurity: vi.fn().mockResolvedValue({
     allowed: true,
     blockedIPs: [],

--- a/test/unit/cache-stampede.test.ts
+++ b/test/unit/cache-stampede.test.ts
@@ -19,6 +19,8 @@ vi.mock('axios');
 vi.mock('open-graph-scraper');
 vi.mock('../../src/utils/enhanced-secure-agent', () => ({
   getEnhancedSecureAgentForUrl: vi.fn(() => null),
+  getEnhancedSecureHttpAgent: vi.fn(() => null),
+  getEnhancedSecureHttpsAgent: vi.fn(() => null),
   validateRequestSecurity: vi.fn(() => Promise.resolve({ allowed: true }))
 }));
 

--- a/test/unit/fetch-image-svg-sanitization.test.ts
+++ b/test/unit/fetch-image-svg-sanitization.test.ts
@@ -7,6 +7,8 @@ import { fetchImage } from '../../src/core/metadata-extractor';
 vi.mock('axios');
 vi.mock('../../src/utils/enhanced-secure-agent', () => ({
   getEnhancedSecureAgentForUrl: vi.fn(() => undefined),
+  getEnhancedSecureHttpAgent: vi.fn(() => undefined),
+  getEnhancedSecureHttpsAgent: vi.fn(() => undefined),
   validateRequestSecurity: vi.fn().mockResolvedValue({
     allowed: true,
     blockedIPs: [],

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -10,7 +10,9 @@ vi.mock('axios');
 vi.mock('open-graph-scraper');
 vi.mock('../../src/utils/image-security');
 vi.mock('../../src/utils/enhanced-secure-agent', () => ({
-  getEnhancedSecureAgentForUrl: vi.fn(() => undefined),
+  getEnhancedSecureAgentForUrl: vi.fn(() => ({ kind: 'protocol-selected' })),
+  getEnhancedSecureHttpAgent: vi.fn(() => ({ kind: 'http' })),
+  getEnhancedSecureHttpsAgent: vi.fn(() => ({ kind: 'https' })),
   validateRequestSecurity: vi.fn().mockResolvedValue({
     allowed: true,
     blockedIPs: [],
@@ -129,6 +131,76 @@ describe('Metadata Extractor', () => {
 
       await expect(extractMetadata(testUrl)).rejects.toThrow('Failed to fetch data');
     });
+
+    it('disables implicit environment proxies and configures protocol-specific secure agents', async () => {
+      const testUrl = 'https://proxy-boundary.example/page';
+
+      mockedAxios.get.mockResolvedValueOnce({ data: mockHtmlMinimal });
+      mockedOgs.mockResolvedValueOnce({
+        error: false,
+        result: { dcTitle: 'Proxy boundary' },
+        html: mockHtmlMinimal,
+        response: {} as any,
+      });
+
+      await extractMetadata(testUrl);
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        `${testUrl}`,
+        expect.objectContaining({
+          proxy: false,
+          httpAgent: { kind: 'http' },
+          httpsAgent: { kind: 'https' },
+        })
+      );
+    });
+
+    it('blocks HTTPS-only requests from redirecting to HTTP', async () => {
+      const testUrl = 'https://redirect-boundary.example/page';
+
+      mockedAxios.get.mockResolvedValueOnce({ data: mockHtmlMinimal });
+      mockedOgs.mockResolvedValueOnce({
+        error: false,
+        result: { dcTitle: 'Redirect boundary' },
+        html: mockHtmlMinimal,
+        response: {} as any,
+      });
+
+      await extractMetadata(testUrl, { httpsOnly: true });
+
+      const requestConfig = mockedAxios.get.mock.calls[0][1];
+      const beforeRedirect = requestConfig?.beforeRedirect;
+
+      expect(beforeRedirect).toBeTypeOf('function');
+      expect(() =>
+        beforeRedirect?.(
+          {
+            protocol: 'https:',
+            hostname: 'proxy.example',
+            path: 'http://redirect.example/',
+            href: 'http://redirect.example/',
+          },
+          { headers: {}, statusCode: 302 }
+        )
+      ).toThrow('HTTPS-only mode');
+      expect(() =>
+        beforeRedirect?.(
+          {
+            protocol: 'https:',
+            hostname: 'proxy.example',
+            path: 'https://redirect.example/',
+            href: 'https://redirect.example/',
+          },
+          { headers: {}, statusCode: 302 }
+        )
+      ).not.toThrow();
+      expect(() =>
+        beforeRedirect?.(
+          { protocol: 'https:', hostname: 'redirect.example', path: '/' },
+          { headers: {}, statusCode: 302 }
+        )
+      ).toThrow('canonical redirect URL is missing');
+    });
   });
 
   describe('validateMetadata', () => {
@@ -193,6 +265,9 @@ describe('Metadata Extractor', () => {
         maxRedirects: 3,
         maxContentLength: 15 * 1024 * 1024,
         maxBodyLength: 15 * 1024 * 1024,
+        proxy: false,
+        httpAgent: { kind: 'http' },
+        httpsAgent: { kind: 'https' },
       }));
     });
 


### PR DESCRIPTION
## What

- disable Axios environment-proxy discovery for both HTML and image fetches
- configure protocol-specific secure HTTP and HTTPS agents for cross-scheme redirects
- validate the canonical redirect target and fail closed when it is unavailable
- enforce `httpsOnly` across every redirect hop
- add regression coverage for metadata and image request configuration

## Why

Axios automatically honors `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY`. In a proxy-enabled deployment, the secure agent would validate only the proxy socket while the proxy resolved and fetched the attacker-controlled destination, weakening the SSRF boundary. The previous redirect validator also reconstructed the target from proxy-mutated fields and allowed HTTPS-to-HTTP downgrades in `httpsOnly` mode.

This intentionally disables implicit environment proxies. Deployments that require outbound proxying need an explicit trusted-proxy design that preserves destination validation.

## Validation

- regression tests failed before the patch and pass after it
- local `HTTP_PROXY` redirect PoC: proxy received zero requests after the patch
- `pnpm exec vitest run` on 5 affected suites (56 passed)
- `pnpm test` (337 passed)
- `pnpm exec tsc -p test/tsconfig.json --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run verify:package`
