### PR TITLE
fix(runtime): isolate cached results and validate inputs

### DIFF
--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -15,6 +15,8 @@ import {
 import { validateImageBuffer } from '../utils/image-security';
 import { metadataCache } from '../utils/cache';
 import { logger } from '../utils/logger';
+import { MAX_TEXT_LENGTH } from '../constants/security';
+import { truncateText } from '../utils/validators/text';
 
 // Allowed MIME types for images
 const BASE_ALLOWED_MIME_TYPES = new Set([
@@ -448,10 +450,10 @@ function parseMetadata(ogData: Record<string, unknown>, url: string): ExtractedM
     siteName: siteName ? cleanText(siteName) : undefined,
     favicon,
     author: author ? cleanText(author) : undefined,
-    publishedDate,
+    publishedDate: publishedDate ? cleanText(publishedDate) : undefined,
     url,
     domain: urlObj.hostname,
-    locale,
+    locale: cleanText(locale),
   };
 }
 
@@ -459,10 +461,12 @@ function parseMetadata(ogData: Record<string, unknown>, url: string): ExtractedM
  * Clean and normalize text
  */
 function cleanText(text: string): string {
-  return text
+  const cleaned = text
     .replace(/[\n\r]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+
+  return truncateText(cleaned, MAX_TEXT_LENGTH);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ import { processImageForTemplate } from './core/template-image-processing';
 import { getCachedPreview, setCachedPreview } from './utils/preview-cache';
 import { svgCache } from './utils/sharp-cache';
 import { startCacheCleanup, isCacheCleanupRunning } from './utils/cache';
+import { MAX_TEXT_LENGTH } from './constants/security';
+import { exceedsTextLength } from './utils/validators/text';
 
 // Initialize Sharp security settings (no side-effect timers at import time)
 initializeSharpSecurity();
@@ -75,7 +77,7 @@ function createPreviewResult(
       width: finalOptions.width || DEFAULT_DIMENSIONS.width,
       height: finalOptions.height || DEFAULT_DIMENSIONS.height,
     },
-    metadata,
+    metadata: { ...metadata },
     template: finalOptions.template || 'modern',
     cached: false,
   };
@@ -91,6 +93,13 @@ function normalizeOptionalMetadataText(
 
   if (typeof value !== 'string') {
     throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, `${fieldName} must be a string`);
+  }
+
+  if (exceedsTextLength(value)) {
+    throw new PreviewGeneratorError(
+      ErrorType.VALIDATION_ERROR,
+      `${fieldName} exceeds maximum length of ${MAX_TEXT_LENGTH} characters`
+    );
   }
 
   const normalized = sanitizeControlChars(value)

--- a/src/utils/preview-cache.ts
+++ b/src/utils/preview-cache.ts
@@ -2,6 +2,15 @@ import crypto from 'crypto';
 import { GeneratedPreview, PreviewOptions } from '../types';
 import { previewCache } from './cache';
 
+function cloneGeneratedPreview(preview: GeneratedPreview): GeneratedPreview {
+  return {
+    ...preview,
+    buffer: Buffer.from(preview.buffer),
+    dimensions: { ...preview.dimensions },
+    metadata: { ...preview.metadata },
+  };
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (!value || typeof value !== 'object') return false;
   const prototype = Object.getPrototypeOf(value);
@@ -52,7 +61,8 @@ function createPreviewCacheKey(url: string, options: PreviewOptions): string | u
 export function getCachedPreview(url: string, options: PreviewOptions): GeneratedPreview | undefined {
   const key = createPreviewCacheKey(url, options);
   if (!key) return undefined;
-  return previewCache.get(key);
+  const cached = previewCache.get(key);
+  return cached ? cloneGeneratedPreview(cached) : undefined;
 }
 
 export function setCachedPreview(
@@ -63,5 +73,5 @@ export function setCachedPreview(
 ): void {
   const key = createPreviewCacheKey(url, options);
   if (!key) return;
-  previewCache.set(key, preview, ttlMs);
+  previewCache.set(key, cloneGeneratedPreview(preview), ttlMs);
 }

--- a/src/utils/validators/dimensions.ts
+++ b/src/utils/validators/dimensions.ts
@@ -9,6 +9,10 @@ export function validateDimensions(width: number, height: number): void {
     throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, 'Dimensions must be finite numbers');
   }
 
+  if (!Number.isInteger(width) || !Number.isInteger(height)) {
+    throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, 'Dimensions must be integers');
+  }
+
   if (width < DIMENSION_LIMITS.MIN_WIDTH || height < DIMENSION_LIMITS.MIN_HEIGHT) {
     throw new PreviewGeneratorError(
       ErrorType.VALIDATION_ERROR,
@@ -28,8 +32,16 @@ export function validateDimensions(width: number, height: number): void {
  * Validate dimension values.
  */
 export function validateDimension(value: number): ValidatedDimension {
-  if (typeof value !== 'number' || isNaN(value) || value <= 0) {
-    throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, 'Dimension must be a positive number');
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    throw new PreviewGeneratorError(
+      ErrorType.VALIDATION_ERROR,
+      'Dimension must be a positive finite integer'
+    );
   }
 
   // Reasonable limits for image dimensions
@@ -42,4 +54,3 @@ export function validateDimension(value: number): ValidatedDimension {
 
   return value as ValidatedDimension;
 }
-

--- a/src/utils/validators/options.ts
+++ b/src/utils/validators/options.ts
@@ -1,7 +1,11 @@
 import { PreviewGeneratorError, ErrorType, PreviewOptions, SanitizedOptions } from '../../types';
-import { ALLOWED_TEMPLATES, QUALITY_LIMITS } from '../../constants/security';
+import {
+  ALLOWED_TEMPLATES,
+  DIMENSION_LIMITS,
+  QUALITY_LIMITS,
+} from '../../constants/security';
 import { validateColor } from './color';
-import { validateDimension } from './dimensions';
+import { validateDimension, validateDimensions } from './dimensions';
 import { validateTextInput } from './text';
 
 /**
@@ -80,6 +84,13 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
   }
 
   // Validate dimensions
+  if (sanitized.width !== undefined || sanitized.height !== undefined) {
+    validateDimensions(
+      sanitized.width ?? DIMENSION_LIMITS.MIN_WIDTH,
+      sanitized.height ?? DIMENSION_LIMITS.MIN_HEIGHT
+    );
+  }
+
   if (sanitized.width !== undefined) {
     sanitized.width = validateDimension(sanitized.width);
   }
@@ -89,6 +100,17 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
 
   // Validate quality
   if (sanitized.quality !== undefined) {
+    if (
+      typeof sanitized.quality !== 'number' ||
+      !Number.isFinite(sanitized.quality) ||
+      !Number.isInteger(sanitized.quality)
+    ) {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        'Quality must be a finite integer'
+      );
+    }
+
     if (sanitized.quality < QUALITY_LIMITS.MIN || sanitized.quality > QUALITY_LIMITS.MAX) {
       throw new PreviewGeneratorError(
         ErrorType.VALIDATION_ERROR,

--- a/src/utils/validators/text.ts
+++ b/src/utils/validators/text.ts
@@ -18,7 +18,7 @@ export function validateTextInput(text: string, fieldName: string = 'text'): San
   }
 
   // Length check - reasonable limits for text content
-  if (text.length > MAX_TEXT_LENGTH) {
+  if (exceedsTextLength(text)) {
     throw new PreviewGeneratorError(
       ErrorType.VALIDATION_ERROR,
       `${fieldName} exceeds maximum length of ${MAX_TEXT_LENGTH} characters`
@@ -37,6 +37,48 @@ export function validateTextInput(text: string, fieldName: string = 'text'): San
   }
 
   return sanitizedText as SanitizedText;
+}
+
+/**
+ * Check a text limit by Unicode code points without scanning unbounded input in full.
+ */
+export function exceedsTextLength(
+  text: string,
+  maxLength: number = MAX_TEXT_LENGTH
+): boolean {
+  let length = 0;
+  const characters = text[Symbol.iterator]();
+
+  while (!characters.next().done) {
+    length += 1;
+    if (length > maxLength) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Truncate text at a Unicode code-point boundary.
+ */
+export function truncateText(
+  text: string,
+  maxLength: number = MAX_TEXT_LENGTH
+): string {
+  let length = 0;
+  let endIndex = 0;
+
+  for (const character of text) {
+    if (length === maxLength) {
+      return text.slice(0, endIndex);
+    }
+
+    length += 1;
+    endIndex += character.length;
+  }
+
+  return text;
 }
 
 /**
@@ -94,4 +136,3 @@ function isSafeTextInput(text: string): boolean {
 
   return true;
 }
-

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -7,7 +7,7 @@ import {
   generatePreviewFromMetadataWithDetails,
   generatePreviewWithDetails,
 } from '../../src/index';
-import { PreviewOptions } from '../../src/types';
+import { ErrorType, PreviewOptions } from '../../src/types';
 import axios from 'axios';
 import ogs from 'open-graph-scraper';
 import sharp from 'sharp';
@@ -401,6 +401,116 @@ describe('End-to-End Integration Tests', () => {
       expect(first.cached).toBe(false);
       expect(second.cached).toBe(true);
       expect(second.buffer).toBeInstanceOf(Buffer);
+    });
+
+    it('should isolate cached previews from mutations to returned results', async () => {
+      const metadata = {
+        title: 'Immutable Cached Post',
+        description: 'Cached results must not share mutable state.',
+        url: 'https://blog.example.com/posts/immutable-cached-post',
+      };
+
+      const first = await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
+      const expectedBuffer = Buffer.from(first.buffer);
+      const expectedDimensions = { ...first.dimensions };
+      const expectedMetadata = { ...first.metadata };
+
+      first.buffer.fill(0);
+      first.dimensions.width = 1;
+      first.metadata.title = 'poisoned after cache set';
+
+      const second = await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
+      expect(second.buffer).toEqual(expectedBuffer);
+      expect(second.dimensions).toEqual(expectedDimensions);
+      expect(second.metadata).toEqual(expectedMetadata);
+
+      second.buffer.fill(1);
+      second.dimensions.height = 1;
+      second.metadata.description = 'poisoned after cache get';
+
+      const third = await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
+      expect(third.buffer).toEqual(expectedBuffer);
+      expect(third.dimensions).toEqual(expectedDimensions);
+      expect(third.metadata).toEqual(expectedMetadata);
+    });
+
+    it('should not expose metadata extraction cache objects when preview caching is disabled', async () => {
+      const url = 'https://metadata-cache-isolation.example/post';
+      const cachedMetadata = {
+        title: 'Original Extracted Title',
+        description: 'Original extracted description.',
+        url,
+        domain: 'metadata-cache-isolation.example',
+      };
+      metadataCache.set(`${url}:${JSON.stringify({})}`, cachedMetadata);
+
+      const first = await generatePreviewWithDetails(url, { cache: false });
+      first.metadata.title = 'mutated returned metadata';
+
+      const second = await generatePreviewWithDetails(url, { cache: false });
+      expect(second.metadata.title).toBe('Original Extracted Title');
+      expect(cachedMetadata.title).toBe('Original Extracted Title');
+    });
+
+    it('should accept direct metadata text at the 10,000 character boundary', async () => {
+      const title = 'a'.repeat(10_000);
+
+      const result = await generatePreviewFromMetadataWithDetails({
+        title,
+        url: 'https://blog.example.com/posts/max-length-title',
+      });
+
+      expect(result.metadata.title).toHaveLength(10_000);
+    });
+
+    it('should reject direct metadata text above 10,000 raw characters', async () => {
+      await expect(
+        generatePreviewFromMetadataWithDetails({
+          title: 'a'.repeat(10_001),
+          url: 'https://blog.example.com/posts/oversized-title',
+        })
+      ).rejects.toMatchObject({
+        type: ErrorType.VALIDATION_ERROR,
+      });
+    });
+
+    it('should count direct metadata limits by Unicode code points', async () => {
+      await expect(
+        generatePreviewFromMetadataWithDetails({
+          title: 'Unicode Length Boundary',
+          description: '😀'.repeat(10_001),
+          url: 'https://blog.example.com/posts/unicode-length-boundary',
+        })
+      ).rejects.toMatchObject({
+        type: ErrorType.VALIDATION_ERROR,
+      });
+    });
+
+    it('should report undersized dimensions as validation errors', async () => {
+      await expect(
+        generatePreviewFromMetadataWithDetails(
+          {
+            title: 'Undersized Preview',
+            url: 'https://blog.example.com/posts/undersized-preview',
+          },
+          { width: 99 }
+        )
+      ).rejects.toMatchObject({
+        type: ErrorType.VALIDATION_ERROR,
+      });
+    });
+
+    it('should enforce the metadata text limit before whitespace normalization', async () => {
+      await expect(
+        generatePreviewFromMetadataWithDetails({
+          title: 'Raw Length Boundary',
+          description: ' '.repeat(10_001),
+          url: 'https://blog.example.com/posts/raw-length-boundary',
+        })
+      ).rejects.toMatchObject({
+        type: ErrorType.VALIDATION_ERROR,
+        message: 'metadata.description exceeds maximum length of 10000 characters',
+      });
     });
 
     it('should reject invalid canonical URLs', async () => {

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -117,6 +117,32 @@ describe('Metadata Extractor', () => {
       expect(result.favicon).toBe('https://minimal.com/favicon.ico');
     });
 
+    it('should truncate cleaned remote metadata text to 10,000 characters', async () => {
+      const testUrl = 'https://long-metadata.example';
+
+      mockedAxios.get.mockResolvedValueOnce({ data: mockHtmlMinimal });
+      mockedOgs.mockResolvedValueOnce({
+        error: false,
+        result: {
+          ogTitle: `  ${'a'.repeat(9_999)}😀z  `,
+          ogDescription: 'b'.repeat(10_001),
+          ogArticlePublishedTime: 'c'.repeat(10_001),
+          ogLocale: 'd'.repeat(10_001),
+        },
+        html: mockHtmlMinimal,
+        response: {} as any,
+      });
+
+      const result = await extractMetadata(testUrl);
+
+      expect(Array.from(result.title)).toHaveLength(10_000);
+      expect(result.description).toHaveLength(10_000);
+      expect(result.title).toBe(`${'a'.repeat(9_999)}😀`);
+      expect(result.description).toBe('b'.repeat(10_000));
+      expect(result.publishedDate).toBe('c'.repeat(10_000));
+      expect(result.locale).toBe('d'.repeat(10_000));
+    });
+
     it('should throw error for invalid URL', async () => {
       const invalidUrl = 'not-a-url';
 

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -144,6 +144,8 @@ describe('Validators', () => {
       expect(() => validateDimensions(50, 100)).toThrow(PreviewGeneratorError);
       expect(() => validateDimensions(5000, 1000)).toThrow(PreviewGeneratorError);
       expect(() => validateDimensions(NaN, 100)).toThrow(PreviewGeneratorError);
+      expect(() => validateDimensions(Infinity, 100)).toThrow(PreviewGeneratorError);
+      expect(() => validateDimensions(1200.5, 630)).toThrow(PreviewGeneratorError);
     });
   });
 
@@ -216,6 +218,28 @@ describe('Validators', () => {
         expect((error as PreviewGeneratorError).type).toBe(ErrorType.VALIDATION_ERROR);
         expect((error as PreviewGeneratorError).message).toContain('Fonts option must be an array');
       }
+    });
+
+    test.each([
+      { width: 1200.5 },
+      { height: 630.5 },
+      { width: NaN },
+      { height: Infinity },
+    ])('should reject non-integer or non-finite dimensions: %o', options => {
+      expect(() => sanitizeOptions(options)).toThrow(PreviewGeneratorError);
+    });
+
+    test.each([
+      { quality: 90.5 },
+      { quality: NaN },
+      { quality: Infinity },
+      { quality: '90' as unknown as number },
+    ])('should reject invalid quality values: %o', options => {
+      expect(() => sanitizeOptions(options)).toThrow(PreviewGeneratorError);
+    });
+
+    test.each([1, 90, 100])('should accept integer quality %i', quality => {
+      expect(sanitizeOptions({ quality }).quality).toBe(quality);
     });
   });
 


### PR DESCRIPTION
## Summary
- clone preview buffers, dimensions, and metadata at cache boundaries so caller mutation cannot poison later results
- enforce finite integer dimensions and quality, including minimum dimensions before image errors can wrap validation failures
- cap caller metadata at 10,000 Unicode code points and safely truncate remote metadata without splitting surrogate pairs

## Verification
- `pnpm exec vitest run test/integration/end-to-end.test.ts test/unit/metadata-extractor.test.ts test/unit/utils/validators.test.ts` (73 passed)
- `pnpm test` (24 files, 455 passed)
- `pnpm run lint`
- `pnpm exec tsc -p test/tsconfig.json --noEmit`
- `pnpm run build`
- `git diff --check origin/master...HEAD`

## Compatibility
No dependency or public type changes. Newly rejected inputs are fractional or non-finite dimensions/quality, dimensions below the existing minimum, and caller metadata above the existing 10,000-character limit.