### PR TITLE
ci(release): verify package contract before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,12 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22.13.0', '24']
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -79,7 +84,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
 
       - name: Install dependencies
@@ -88,8 +93,8 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Verify package contents
-        run: npm pack --dry-run
+      - name: Verify synthetic release tag contract
+        run: pnpm run verify:release -- --tag "v$(node -p "require('./package.json').version")"
 
-      - name: Verify production package import
+      - name: Verify packed package
         run: pnpm run verify:package

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,11 +3,16 @@ name: Publish to NPM
 on:
   push:
     tags:
-      - 'v*'  # Trigger on version tags like v0.1.0, v1.0.0
+      - 'v*' # Trigger on version tags like v0.1.0, v1.0.0
+
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -15,6 +20,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -24,18 +32,55 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
+
+      - name: Verify release contract and tag ancestry
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          tag_ref="refs/tags/$RELEASE_TAG"
+          if [[ "$(git cat-file -t "$tag_ref")" != "tag" ]]; then
+            echo "Release tag must be an annotated tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          tag_commit="$(git rev-parse "$tag_ref^{commit}")"
+          checked_out_commit="$(git rev-parse HEAD)"
+          if [[ "$tag_commit" != "$checked_out_commit" ]]; then
+            echo "Release tag commit $tag_commit does not match checkout $checked_out_commit" >&2
+            exit 1
+          fi
+
+          if ! git show-ref --verify --quiet refs/remotes/origin/master; then
+            echo "origin/master is unavailable; full checkout is required" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/master; then
+            echo "Release tag commit must be reachable from origin/master" >&2
+            exit 1
+          fi
+
+          pnpm run verify:release -- --tag "$RELEASE_TAG"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run lint
+        run: pnpm run lint
+
       - name: Run build
         run: pnpm run build
 
-      - name: Run tests
+      - name: Run full test suite
         run: pnpm test
         env:
           SKIP_NETWORK_TESTS: 'true'
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level=high
+
+      - name: Verify packed package
+        run: pnpm run verify:package -- --output verified-package.tgz
 
       - name: Publish to npm
         run: |
@@ -43,4 +88,4 @@ jobs:
           unset NODE_AUTH_TOKEN || true
           unset NPM_CONFIG_USERCONFIG || true
           # Use npm publish for --provenance (OIDC attestation), which pnpm does not support
-          npm publish --access public --provenance
+          npm publish ./verified-package.tgz --access public --provenance

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint src",
     "format": "prettier --write 'src/**/*.ts'",
     "verify:package": "node scripts/verify-packed-package.mjs",
+    "verify:release": "node scripts/verify-release-contract.mjs",
     "prepublishOnly": "pnpm run build && pnpm test"
   },
   "keywords": [
@@ -39,6 +40,9 @@
     "url": "https://github.com/nanggo/social-preview-generator/issues"
   },
   "homepage": "https://github.com/nanggo/social-preview-generator#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist",
     "README.md"

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -1,12 +1,205 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 
+const PACKAGE_NAME = '@nanggo/social-preview';
+const EXPECTED_RUNTIME_EXPORTS = [
+  'ErrorType',
+  'PreviewGeneratorError',
+  'clearAllCaches',
+  'clearInflightRequests',
+  'generateImageWithTemplate',
+  'generatePreview',
+  'generatePreviewFromMetadata',
+  'generatePreviewFromMetadataWithDetails',
+  'generatePreviewWithDetails',
+  'getCacheStats',
+  'getInflightRequestStats',
+  'isCacheCleanupRunning',
+  'shutdownSharpCaches',
+  'startCacheCleanup',
+  'stopCacheCleanup',
+];
+const repositoryRoot = process.cwd();
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'social-preview-package-smoke-'));
 const consumerDirectory = join(temporaryRoot, 'consumer');
 const npmCacheDirectory = join(temporaryRoot, 'npm-cache');
+const requireFromVerifier = createRequire(import.meta.url);
+
+function parseArguments(argv) {
+  let outputPath;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === '--') {
+      continue;
+    }
+    if (argument !== '--output') {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error('Missing value for --output');
+    }
+
+    outputPath = resolve(repositoryRoot, value);
+    index += 1;
+  }
+
+  return { outputPath };
+}
+
+function collectTypeScriptSources(directory) {
+  const sourcePaths = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      sourcePaths.push(...collectTypeScriptSources(absolutePath));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      sourcePaths.push(relative(join(repositoryRoot, 'src'), absolutePath).replaceAll('\\', '/'));
+    }
+  }
+
+  return sourcePaths;
+}
+
+function verifyTarballContents(packResult) {
+  const actualPaths = (packResult.files ?? []).map((file) => file.path).sort();
+  const expectedPaths = ['LICENSE', 'README.md', 'package.json'];
+
+  for (const sourcePath of collectTypeScriptSources(join(repositoryRoot, 'src'))) {
+    const outputBase = `dist/${sourcePath.slice(0, -'.ts'.length)}`;
+    expectedPaths.push(`${outputBase}.d.ts`, `${outputBase}.js`);
+  }
+
+  expectedPaths.sort();
+
+  const missing = expectedPaths.filter((path) => !actualPaths.includes(path));
+  const forbidden = actualPaths.filter((path) => !expectedPaths.includes(path));
+
+  if (missing.length > 0 || forbidden.length > 0) {
+    const messages = [];
+    if (missing.length > 0) {
+      messages.push(`missing files: ${missing.join(', ')}`);
+    }
+    if (forbidden.length > 0) {
+      messages.push(`unexpected or forbidden files: ${forbidden.join(', ')}`);
+    }
+    throw new Error(`Packed tarball contents are invalid (${messages.join('; ')})`);
+  }
+}
+
+function verifyRuntimeExports(packageExports) {
+  const actualExports = Object.keys(packageExports).sort();
+  const expectedExports = [...EXPECTED_RUNTIME_EXPORTS].sort();
+
+  if (JSON.stringify(actualExports) !== JSON.stringify(expectedExports)) {
+    throw new Error(
+      `Packed package runtime exports changed: expected ${expectedExports.join(', ')}, received ${actualExports.join(', ')}`
+    );
+  }
+
+  for (const exportName of expectedExports) {
+    const expectedType = exportName === 'ErrorType' ? 'object' : 'function';
+    if (typeof packageExports[exportName] !== expectedType) {
+      throw new Error(`Packed package export ${exportName} must be a ${expectedType}`);
+    }
+  }
+}
+
+function verifyEsmImport() {
+  const esmCheck = `
+    const packageExports = await import(${JSON.stringify(PACKAGE_NAME)});
+    for (const exportName of ${JSON.stringify(EXPECTED_RUNTIME_EXPORTS)}) {
+      if (!(exportName in packageExports)) {
+        throw new Error('ESM import is missing ' + exportName);
+      }
+    }
+  `;
+
+  execFileSync(process.execPath, ['--input-type=module', '--eval', esmCheck], {
+    cwd: consumerDirectory,
+    stdio: 'inherit',
+  });
+}
+
+function verifyTypeScriptConsumer() {
+  const nodeTypesRoot = dirname(dirname(requireFromVerifier.resolve('@types/node/package.json')));
+  const typescriptEntrypoint = requireFromVerifier.resolve('typescript');
+  const tscPath = join(dirname(typescriptEntrypoint), '..', 'bin', 'tsc');
+
+  writeFileSync(
+    join(consumerDirectory, 'consumer.ts'),
+    `
+      import {
+        ErrorType,
+        PreviewGeneratorError,
+        generateImageWithTemplate,
+        generatePreviewFromMetadata,
+        generatePreviewWithDetails,
+        type ExtractedMetadata,
+        type GeneratedPreview,
+        type PreviewMetadataInput,
+        type PreviewOptions,
+        type TemplateConfig,
+      } from '${PACKAGE_NAME}';
+
+      const metadata: PreviewMetadataInput = {
+        title: 'TypeScript package smoke',
+        url: 'https://example.com/typescript-smoke',
+      };
+      const options: PreviewOptions = { width: 320, height: 168, template: 'minimal' };
+      const extracted: ExtractedMetadata = metadata;
+      const template: TemplateConfig = {
+        name: 'consumer-smoke',
+        layout: { padding: 20 },
+        typography: { title: { fontSize: 32 } },
+      };
+      const typedError: PreviewGeneratorError = new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        'consumer smoke'
+      );
+      const rendered: Promise<Buffer> = generatePreviewFromMetadata(metadata, options);
+      const detailed: Promise<GeneratedPreview> = generatePreviewWithDetails(metadata.url, options);
+      const custom: Promise<Buffer> = generateImageWithTemplate(extracted, template, options);
+      void rendered;
+      void detailed;
+      void custom;
+      void typedError;
+    `
+  );
+  writeFileSync(
+    join(consumerDirectory, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        esModuleInterop: true,
+        module: 'Node16',
+        moduleResolution: 'Node16',
+        noEmit: true,
+        skipLibCheck: false,
+        strict: true,
+        target: 'ES2022',
+        typeRoots: [nodeTypesRoot],
+        types: ['node'],
+      },
+      include: ['consumer.ts'],
+    })
+  );
+
+  execFileSync(process.execPath, [tscPath, '--project', join(consumerDirectory, 'tsconfig.json')], {
+    cwd: consumerDirectory,
+    stdio: 'inherit',
+  });
+}
+
+const { outputPath } = parseArguments(process.argv.slice(2));
+let packageExports;
 
 try {
   const packOutput = execFileSync(
@@ -14,14 +207,21 @@ try {
     ['pack', '--json', '--pack-destination', temporaryRoot, '--cache', npmCacheDirectory],
     { encoding: 'utf8' }
   );
-  const packResult = JSON.parse(packOutput);
-  const packageFilename = packResult[0]?.filename;
+  const packResults = JSON.parse(packOutput);
+  const packResult = packResults[0];
+  const packageFilename = packResult?.filename;
 
-  if (!packageFilename) {
-    throw new Error('npm pack did not return a package filename');
+  if (packResults.length !== 1 || !packageFilename) {
+    throw new Error('npm pack did not return exactly one package filename');
   }
 
+  verifyTarballContents(packResult);
+
   mkdirSync(consumerDirectory);
+  writeFileSync(
+    join(consumerDirectory, 'package.json'),
+    JSON.stringify({ name: 'social-preview-package-smoke', private: true })
+  );
   execFileSync(
     'npm',
     [
@@ -40,13 +240,43 @@ try {
   );
 
   const requireFromConsumer = createRequire(join(consumerDirectory, 'package.json'));
-  const packageExports = requireFromConsumer('@nanggo/social-preview');
+  packageExports = requireFromConsumer(PACKAGE_NAME);
+  verifyRuntimeExports(packageExports);
+  verifyEsmImport();
 
-  if (typeof packageExports.generatePreview !== 'function') {
-    throw new Error('Packed package did not expose generatePreview');
+  const image = await packageExports.generatePreviewFromMetadata(
+    {
+      title: 'Packed package render smoke',
+      url: 'https://example.com/package-smoke',
+    },
+    { cache: false, height: 168, template: 'minimal', width: 320 }
+  );
+  const sharp = requireFromConsumer('sharp');
+  const imageMetadata = await sharp(image).metadata();
+
+  if (!Buffer.isBuffer(image) || imageMetadata.format !== 'jpeg') {
+    throw new Error('Packed package did not render a JPEG buffer');
+  }
+  if (imageMetadata.width !== 320 || imageMetadata.height !== 168) {
+    throw new Error(
+      `Packed package rendered ${imageMetadata.width}x${imageMetadata.height}; expected 320x168`
+    );
   }
 
-  console.log('Packed package imported successfully from a production-only install.');
+  verifyTypeScriptConsumer();
+
+  if (outputPath) {
+    mkdirSync(dirname(outputPath), { recursive: true });
+    copyFileSync(join(temporaryRoot, basename(packageFilename)), outputPath);
+  }
+
+  console.log(
+    'Packed package passed tarball, CJS/ESM import, runtime export, 320x168 JPEG, and TypeScript consumer checks.'
+  );
+  if (outputPath) {
+    console.log(`Verified tarball written to ${outputPath}.`);
+  }
 } finally {
+  packageExports?.stopCacheCleanup?.();
   rmSync(temporaryRoot, { force: true, recursive: true });
 }

--- a/scripts/verify-release-contract.mjs
+++ b/scripts/verify-release-contract.mjs
@@ -1,0 +1,143 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const EXPECTED_PACKAGE_NAME = '@nanggo/social-preview';
+const EXPECTED_REPOSITORY = {
+  type: 'git',
+  url: 'git+https://github.com/nanggo/social-preview-generator.git',
+};
+const EXPECTED_EXPORTS = {
+  '.': {
+    types: './dist/index.d.ts',
+    default: './dist/index.js',
+  },
+};
+const EXPECTED_FILES = ['README.md', 'dist'];
+const EXPECTED_ENGINES = { node: '^22.13.0 || >=24.0.0' };
+const EXPECTED_PUBLISH_CONFIG = { access: 'public' };
+const STABLE_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function parseArguments(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === '--') {
+      continue;
+    }
+
+    if (argument !== '--package-json' && argument !== '--tag') {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${argument}`);
+    }
+
+    options[argument.slice(2)] = value;
+    index += 1;
+  }
+
+  return options;
+}
+
+function normalizeForComparison(value) {
+  if (Array.isArray(value)) {
+    return value.map(normalizeForComparison);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, normalizeForComparison(nestedValue)])
+    );
+  }
+
+  return value;
+}
+
+function isDeepEqual(actual, expected) {
+  return (
+    JSON.stringify(normalizeForComparison(actual)) ===
+    JSON.stringify(normalizeForComparison(expected))
+  );
+}
+
+export function verifyReleaseContract(manifest, releaseTag) {
+  const violations = [];
+
+  if (manifest.name !== EXPECTED_PACKAGE_NAME) {
+    violations.push(`package name must be ${EXPECTED_PACKAGE_NAME}`);
+  }
+
+  if (typeof manifest.version !== 'string' || !STABLE_SEMVER.test(manifest.version)) {
+    violations.push('package version must be a stable x.y.z semantic version');
+  }
+
+  if (!releaseTag) {
+    violations.push('release tag is required');
+  } else if (releaseTag !== `v${manifest.version}`) {
+    violations.push(`release tag must exactly match v${manifest.version}`);
+  }
+
+  if (!isDeepEqual(manifest.repository, EXPECTED_REPOSITORY)) {
+    violations.push(`repository must be ${JSON.stringify(EXPECTED_REPOSITORY)}`);
+  }
+
+  if (manifest.main !== 'dist/index.js') {
+    violations.push('main must be dist/index.js');
+  }
+
+  if (manifest.types !== 'dist/index.d.ts') {
+    violations.push('types must be dist/index.d.ts');
+  }
+
+  if (!isDeepEqual(manifest.exports, EXPECTED_EXPORTS)) {
+    violations.push(`exports must be ${JSON.stringify(EXPECTED_EXPORTS)}`);
+  }
+
+  const files = Array.isArray(manifest.files) ? [...manifest.files].sort() : manifest.files;
+  if (!isDeepEqual(files, EXPECTED_FILES)) {
+    violations.push(`files must contain only ${EXPECTED_FILES.join(' and ')}`);
+  }
+
+  if (!isDeepEqual(manifest.engines, EXPECTED_ENGINES)) {
+    violations.push(`engines must be ${JSON.stringify(EXPECTED_ENGINES)}`);
+  }
+
+  if (!isDeepEqual(manifest.publishConfig, EXPECTED_PUBLISH_CONFIG)) {
+    violations.push(`publishConfig must be ${JSON.stringify(EXPECTED_PUBLISH_CONFIG)}`);
+  }
+
+  if (manifest.private === true) {
+    violations.push('package must not be marked private');
+  }
+
+  if (violations.length > 0) {
+    throw new Error(`Release contract validation failed:\n- ${violations.join('\n- ')}`);
+  }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+const modulePath = resolve(fileURLToPath(import.meta.url));
+
+if (invokedPath === modulePath) {
+  try {
+    const options = parseArguments(process.argv.slice(2));
+    const packageJsonPath = resolve(options['package-json'] ?? 'package.json');
+    const releaseTag = options.tag ?? process.env.RELEASE_TAG ?? process.env.GITHUB_REF_NAME;
+    const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+    verifyReleaseContract(manifest, releaseTag);
+    console.log(
+      `Release contract verified for ${manifest.name}@${manifest.version} (${releaseTag}).`
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/test/unit/release-contract.test.ts
+++ b/test/unit/release-contract.test.ts
@@ -1,0 +1,165 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const verifierPath = resolve(process.cwd(), 'scripts/verify-release-contract.mjs');
+const sourceManifest = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8'));
+const matchingTag = `v${sourceManifest.version}`;
+const temporaryDirectories: string[] = [];
+
+function cloneManifest(): Record<string, any> {
+  return structuredClone(sourceManifest);
+}
+
+function writeManifest(manifest: Record<string, any>): string {
+  const directory = mkdtempSync(join(tmpdir(), 'social-preview-release-contract-'));
+  const packageJsonPath = join(directory, 'package.json');
+  temporaryDirectories.push(directory);
+  writeFileSync(packageJsonPath, JSON.stringify(manifest));
+  return packageJsonPath;
+}
+
+function verifyFailure(manifest: Record<string, any>, tag: string) {
+  return spawnSync(
+    process.execPath,
+    [verifierPath, '--package-json', writeManifest(manifest), '--tag', tag],
+    { encoding: 'utf8' }
+  );
+}
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) {
+    rmSync(temporaryDirectories.pop()!, { force: true, recursive: true });
+  }
+});
+
+describe('release contract verifier', () => {
+  it('accepts the repository package and its matching synthetic tag', () => {
+    const packageJsonPath = writeManifest(cloneManifest());
+
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        [verifierPath, '--package-json', packageJsonPath, '--tag', matchingTag],
+        { encoding: 'utf8' }
+      )
+    ).not.toThrow();
+  });
+
+  it('can be imported without executing the CLI path', () => {
+    const importCheck = `
+      process.argv.push('--not-a-verifier-argument');
+      const verifier = await import(${JSON.stringify(pathToFileURL(verifierPath).href)});
+      verifier.verifyReleaseContract(
+        ${JSON.stringify(sourceManifest)},
+        ${JSON.stringify(matchingTag)}
+      );
+    `;
+    const result = spawnSync(process.execPath, ['--input-type=module', '--eval', importCheck], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+
+  it.each([
+    [
+      'a prerelease version',
+      (manifest: Record<string, any>) => {
+        manifest.version = `${sourceManifest.version}-rc.1`;
+      },
+      `${matchingTag}-rc.1`,
+      'stable x.y.z semantic version',
+    ],
+    [
+      'a tag that does not match the package version',
+      (_manifest: Record<string, any>) => {},
+      'v999.999.999',
+      `release tag must exactly match ${matchingTag}`,
+    ],
+    [
+      'a different package name',
+      (manifest: Record<string, any>) => {
+        manifest.name = '@nanggo/other-package';
+      },
+      matchingTag,
+      'package name must be @nanggo/social-preview',
+    ],
+    [
+      'a different repository',
+      (manifest: Record<string, any>) => {
+        manifest.repository.url = 'git+https://github.com/example/fork.git';
+      },
+      matchingTag,
+      'repository must be',
+    ],
+    [
+      'a missing runtime entry point',
+      (manifest: Record<string, any>) => {
+        manifest.main = 'index.js';
+      },
+      matchingTag,
+      'main must be dist/index.js',
+    ],
+    [
+      'a missing type entry point',
+      (manifest: Record<string, any>) => {
+        manifest.types = 'index.d.ts';
+      },
+      matchingTag,
+      'types must be dist/index.d.ts',
+    ],
+    [
+      'a changed root export',
+      (manifest: Record<string, any>) => {
+        manifest.exports['.'].default = './index.js';
+      },
+      matchingTag,
+      'exports must be',
+    ],
+    [
+      'an unsafe published file list',
+      (manifest: Record<string, any>) => {
+        manifest.files.push('src');
+      },
+      matchingTag,
+      'files must contain only README.md and dist',
+    ],
+    [
+      'non-public publish access',
+      (manifest: Record<string, any>) => {
+        manifest.publishConfig.access = 'restricted';
+      },
+      matchingTag,
+      'publishConfig must be',
+    ],
+    [
+      'extra publish registry and dist-tag configuration',
+      (manifest: Record<string, any>) => {
+        manifest.publishConfig.registry = 'https://example.invalid/';
+        manifest.publishConfig.tag = 'next';
+      },
+      matchingTag,
+      'publishConfig must be',
+    ],
+    [
+      'a changed Node.js support range',
+      (manifest: Record<string, any>) => {
+        manifest.engines.node = '>=18';
+      },
+      matchingTag,
+      'engines must be',
+    ],
+  ])('rejects %s', (_description, mutate, tag, expectedMessage) => {
+    const manifest = cloneManifest();
+    mutate(manifest);
+
+    const result = verifyFailure(manifest, tag);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(expectedMessage);
+  });
+});


### PR DESCRIPTION
## Summary
- fail release jobs unless an annotated `vX.Y.Z` tag exactly matches the package contract and points to a commit reachable from `origin/master`
- gate publish on lint, build, full tests, production audit, and packed-package verification on the supported Node lines
- verify tarball contents, CJS/ESM imports, every root public type, and a real 320x168 JPEG render, then publish that exact verified tarball

## Verification
- `pnpm test` (25 files, 467 passed)
- `pnpm run lint`
- `pnpm exec tsc -p test/tsconfig.json --noEmit`
- `pnpm run build`
- `pnpm run verify:release -- --tag v0.2.6`
- `node scripts/verify-packed-package.mjs --output /private/tmp/verified-social-preview-latest.tgz`
- `npm publish /private/tmp/verified-social-preview.tgz --dry-run --foreground-scripts` (tarball accepted; no publish performed)
- Prettier and `git diff --check`

## Release safety
This PR does not change version, dependencies, lockfile, tags, or npm state. The workflow keeps Trusted Publishing OIDC and will publish only the artifact already exercised by the consumer smoke.