### PR TITLE
fix(render): report effective fallback metadata

### DIFF
--- a/src/core/image-generator.ts
+++ b/src/core/image-generator.ts
@@ -26,6 +26,12 @@ export const DEFAULT_DIMENSIONS = {
   height: 630,
 };
 
+export interface FallbackImageResult {
+  buffer: Buffer;
+  metadata: ExtractedMetadata;
+  template: 'fallback';
+}
+
 /**
  * Generate image buffer from metadata and template
  */
@@ -327,6 +333,17 @@ export async function createFallbackImage(
   url: string,
   options: PreviewOptions = {}
 ): Promise<Buffer> {
+  const result = await createFallbackImageWithDetails(url, options);
+  return result.buffer;
+}
+
+/**
+ * Create a fallback image and report the exact render inputs.
+ */
+export async function createFallbackImageWithDetails(
+  url: string,
+  options: PreviewOptions = {}
+): Promise<FallbackImageResult> {
   try {
     const urlObj = new URL(url);
     const domain = urlObj.hostname;
@@ -362,7 +379,13 @@ export async function createFallbackImage(
       },
     };
 
-    return await generateImage(fallbackMetadata, fallbackTemplate, options);
+    const buffer = await generateImage(fallbackMetadata, fallbackTemplate, options);
+
+    return {
+      buffer,
+      metadata: { ...fallbackMetadata },
+      template: 'fallback',
+    };
   } catch (error) {
     throw new PreviewGeneratorError(
       ErrorType.IMAGE_ERROR,

--- a/src/core/template-image-processing.ts
+++ b/src/core/template-image-processing.ts
@@ -6,36 +6,60 @@ import { secureResize, withSecureSharp } from '../utils/image-security';
 import { fetchImage } from './metadata-extractor';
 import { createBlankCanvas } from './image-generator';
 
+export interface ProcessedTemplateImage {
+  baseImage: Sharp;
+  effectiveMetadata: ExtractedMetadata;
+  usedBackgroundImage: boolean;
+}
+
 export async function processImageForTemplate(
   metadata: ExtractedMetadata,
   template: TemplateConfig,
   width: number,
   height: number,
   options: SanitizedOptions
-): Promise<Sharp> {
+): Promise<ProcessedTemplateImage> {
+  const effectiveMetadata = { ...metadata };
+
   // Check if template wants no background image
   if (template.layout.imagePosition === 'none') {
     // Use transparent canvas if template requires it, otherwise use blank canvas
     if (template.imageProcessing?.requiresTransparentCanvas) {
-      return createTransparentCanvas(width, height);
+      return {
+        baseImage: createTransparentCanvas(width, height),
+        effectiveMetadata,
+        usedBackgroundImage: false,
+      };
     }
-    return await createBlankCanvas(width, height, options);
+    return {
+      baseImage: await createBlankCanvas(width, height, options),
+      effectiveMetadata,
+      usedBackgroundImage: false,
+    };
   }
 
   // If no image available, handle based on template configuration
   if (!metadata.image) {
     // Use transparent canvas if template requires it for custom backgrounds
     if (template.imageProcessing?.requiresTransparentCanvas) {
-      return createTransparentCanvas(width, height);
+      return {
+        baseImage: createTransparentCanvas(width, height),
+        effectiveMetadata,
+        usedBackgroundImage: false,
+      };
     }
-    return await createBlankCanvas(width, height, options);
+    return {
+      baseImage: await createBlankCanvas(width, height, options),
+      effectiveMetadata,
+      usedBackgroundImage: false,
+    };
   }
 
   // Process background image with template-specific effects
   try {
     const imageBuffer = await fetchImage(metadata.image, options.security);
 
-    return await withSecureSharp(imageBuffer, async (secureImage) => {
+    const baseImage = await withSecureSharp(imageBuffer, async (secureImage) => {
       let processedImage = secureResize(secureImage, width, height, {
         fit: 'cover',
         position: 'center',
@@ -68,6 +92,8 @@ export async function processImageForTemplate(
 
       return processedImage;
     });
+
+    return { baseImage, effectiveMetadata, usedBackgroundImage: true };
   } catch (fetchError) {
     // If image fetch fails, create appropriate canvas based on template configuration
     logImageFetchError(
@@ -75,10 +101,20 @@ export async function processImageForTemplate(
       fetchError instanceof Error ? fetchError : new Error(String(fetchError))
     );
 
+    const metadataWithoutFailedImage = { ...metadata, image: undefined };
+
     // Use transparent canvas if template requires it for custom backgrounds
     if (template.imageProcessing?.requiresTransparentCanvas) {
-      return createTransparentCanvas(width, height);
+      return {
+        baseImage: createTransparentCanvas(width, height),
+        effectiveMetadata: metadataWithoutFailedImage,
+        usedBackgroundImage: false,
+      };
     }
-    return await createBlankCanvas(width, height, options);
+    return {
+      baseImage: await createBlankCanvas(width, height, options),
+      effectiveMetadata: metadataWithoutFailedImage,
+      usedBackgroundImage: false,
+    };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
   PreviewGeneratorError,
 } from './types';
 import { extractMetadata, validateMetadata, applyFallbacks } from './core/metadata-extractor';
-import { createFallbackImage, DEFAULT_DIMENSIONS } from './core/image-generator';
+import { createFallbackImageWithDetails, DEFAULT_DIMENSIONS } from './core/image-generator';
 import { templates } from './templates/registry';
 import {
   validateDimensions,
@@ -24,9 +24,12 @@ import {
 } from './utils/validators';
 import { initializeSharpSecurity } from './utils/image-security';
 import { generateDefaultOverlay } from './core/overlay-generator';
-import { processImageForTemplate } from './core/template-image-processing';
+import {
+  processImageForTemplate,
+  type ProcessedTemplateImage,
+} from './core/template-image-processing';
 import { getCachedPreview, setCachedPreview } from './utils/preview-cache';
-import { svgCache } from './utils/sharp-cache';
+import { createCachedSVG } from './utils/sharp-cache';
 import { startCacheCleanup, isCacheCleanupRunning } from './utils/cache';
 import { MAX_TEXT_LENGTH } from './constants/security';
 import { exceedsTextLength } from './utils/validators/text';
@@ -152,8 +155,8 @@ async function renderPreviewFromMetadata(
   finalOptions: SanitizedOptions
 ): Promise<GeneratedPreview> {
   const template = getTemplate(finalOptions.template);
-  const buffer = await generateImageWithSanitizedOptions(metadata, template, finalOptions);
-  return createPreviewResult(buffer, metadata, finalOptions);
+  const rendered = await generateImageWithSanitizedOptions(metadata, template, finalOptions);
+  return createPreviewResult(rendered.buffer, rendered.effectiveMetadata, finalOptions);
 }
 
 /**
@@ -191,7 +194,59 @@ export async function generateImageWithTemplate(
   options: PreviewOptions
 ): Promise<Buffer> {
   const sanitizedOptions = sanitizeOptions(options);
-  return generateImageWithSanitizedOptions(metadata, template, sanitizedOptions);
+  const rendered = await generateImageWithSanitizedOptions(metadata, template, sanitizedOptions);
+  return rendered.buffer;
+}
+
+interface RenderedImage {
+  buffer: Buffer;
+  effectiveMetadata: ExtractedMetadata;
+}
+
+async function createOverlayBuffer(
+  effectiveMetadata: ExtractedMetadata,
+  template: TemplateConfig,
+  width: number,
+  height: number,
+  sanitizedOptions: SanitizedOptions
+): Promise<Buffer> {
+  if (template.overlayGenerator) {
+    const overlaySvg = template.overlayGenerator(
+      effectiveMetadata,
+      width,
+      height,
+      sanitizedOptions,
+      template
+    );
+    // Materialize custom SVG overlays before entering the background-image
+    // retry path. Otherwise Sharp can defer an SVG parse error until the final
+    // composite and incorrectly classify it as a failed background image.
+    const overlayImage = await createCachedSVG(overlaySvg);
+    return overlayImage.toBuffer();
+  }
+
+  return generateDefaultOverlay(effectiveMetadata, template, width, height, sanitizedOptions);
+}
+
+function renderProcessedImage(
+  processedImage: ProcessedTemplateImage,
+  overlayBuffer: Buffer,
+  quality: number
+): Promise<Buffer> {
+  return processedImage.baseImage
+    .composite([
+      {
+        input: overlayBuffer,
+        top: 0,
+        left: 0,
+      },
+    ])
+    .jpeg({
+      quality,
+      progressive: true,
+      mozjpeg: true,
+    })
+    .toBuffer();
 }
 
 /**
@@ -201,7 +256,7 @@ async function generateImageWithSanitizedOptions(
   metadata: ExtractedMetadata,
   template: TemplateConfig,
   sanitizedOptions: SanitizedOptions
-): Promise<Buffer> {
+): Promise<RenderedImage> {
   const width = sanitizedOptions.width || DEFAULT_DIMENSIONS.width;
   const height = sanitizedOptions.height || DEFAULT_DIMENSIONS.height;
   const quality = sanitizedOptions.quality || 90;
@@ -209,51 +264,53 @@ async function generateImageWithSanitizedOptions(
   try {
     validateDimensions(width, height);
 
-    const baseImage = await processImageForTemplate(
+    let processedImage = await processImageForTemplate(
       metadata,
       template,
       width,
       height,
       sanitizedOptions
     );
+    let overlayBuffer = await createOverlayBuffer(
+      processedImage.effectiveMetadata,
+      template,
+      width,
+      height,
+      sanitizedOptions
+    );
 
-    let overlayBuffer: Buffer;
+    let finalImage: Buffer;
+    try {
+      finalImage = await renderProcessedImage(processedImage, overlayBuffer, quality);
+    } catch (processingError) {
+      if (!processedImage.usedBackgroundImage) {
+        throw processingError;
+      }
 
-    if (template.overlayGenerator) {
-      const overlaySvg = template.overlayGenerator(
-        metadata,
-        width,
-        height,
-        sanitizedOptions,
-        template
-      );
-      overlayBuffer = svgCache.getCachedSVG(overlaySvg) ?? svgCache.cacheSVG(overlaySvg);
-    } else {
-      overlayBuffer = await generateDefaultOverlay(
-        metadata,
+      // Sharp evaluates image pipelines lazily, so decoding/resizing can fail
+      // only while producing the final buffer. Retry once with the same
+      // metadata minus the failed background image.
+      processedImage = await processImageForTemplate(
+        { ...processedImage.effectiveMetadata, image: undefined },
         template,
         width,
         height,
         sanitizedOptions
       );
+      overlayBuffer = await createOverlayBuffer(
+        processedImage.effectiveMetadata,
+        template,
+        width,
+        height,
+        sanitizedOptions
+      );
+      finalImage = await renderProcessedImage(processedImage, overlayBuffer, quality);
     }
 
-    const finalImage = await baseImage
-      .composite([
-        {
-          input: overlayBuffer,
-          top: 0,
-          left: 0,
-        },
-      ])
-      .jpeg({
-        quality,
-        progressive: true,
-        mozjpeg: true,
-      })
-      .toBuffer();
-
-    return finalImage;
+    return {
+      buffer: finalImage,
+      effectiveMetadata: processedImage.effectiveMetadata,
+    };
   } catch (error) {
     throw new PreviewGeneratorError(
       ErrorType.IMAGE_ERROR,
@@ -302,18 +359,16 @@ export async function generatePreviewWithDetails(
         finalOptions.fallback?.strategy === 'generate' ||
         finalOptions.fallback?.strategy === 'auto'
       ) {
-        const buffer = await createFallbackImage(url, finalOptions);
-        // Create minimal metadata for fallback
-        const fallbackMetadata = applyFallbacks({}, url);
+        const fallback = await createFallbackImageWithDetails(url, finalOptions);
         const fallbackResult: GeneratedPreview = {
-          buffer,
+          buffer: fallback.buffer,
           format: 'jpeg',
           dimensions: {
             width: finalOptions.width || DEFAULT_DIMENSIONS.width,
             height: finalOptions.height || DEFAULT_DIMENSIONS.height,
           },
-          metadata: fallbackMetadata,
-          template: finalOptions.template || 'modern',
+          metadata: fallback.metadata,
+          template: fallback.template,
           cached: false,
         };
         if (shouldCache) {

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -12,6 +12,7 @@ import axios from 'axios';
 import ogs from 'open-graph-scraper';
 import sharp from 'sharp';
 import { metadataCache } from '../../src/utils/cache';
+import { templates } from '../../src/templates/registry';
 
 vi.mock('axios');
 vi.mock('open-graph-scraper');
@@ -295,6 +296,227 @@ describe('End-to-End Integration Tests', () => {
         cached: false,
       });
     });
+
+    it('removes a failed image from the overlay input and reported metadata', async () => {
+      const originalTemplate = templates.modern;
+      const overlayGenerator = vi.fn(
+        () => '<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" />'
+      );
+      templates.modern = { ...originalTemplate, overlayGenerator };
+      mockedAxios.get.mockRejectedValueOnce(new Error('Image fetch failed'));
+
+      try {
+        const result = await generatePreviewFromMetadataWithDetails({
+          title: 'Post With Broken Cover',
+          url: 'https://blog.example.com/posts/broken-cover',
+          image: 'https://cdn.example.com/covers/broken.png',
+        });
+
+        expect(overlayGenerator).toHaveBeenLastCalledWith(
+          expect.objectContaining({ image: undefined }),
+          expect.any(Number),
+          expect.any(Number),
+          expect.any(Object),
+          expect.any(Object)
+        );
+        expect(result.metadata.image).toBeUndefined();
+      } finally {
+        templates.modern = originalTemplate;
+      }
+    });
+
+    it('keeps a successfully processed image in the overlay input and reported metadata', async () => {
+      const originalTemplate = templates.modern;
+      const overlayGenerator = vi.fn(
+        () => '<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" />'
+      );
+      templates.modern = { ...originalTemplate, overlayGenerator };
+      const imageUrl = 'https://cdn.example.com/covers/working.png';
+      const pngImageBuffer = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+        'base64'
+      );
+      mockedAxios.get.mockResolvedValueOnce({
+        data: pngImageBuffer,
+        headers: { 'content-type': 'image/png' },
+      });
+
+      try {
+        const result = await generatePreviewFromMetadataWithDetails({
+          title: 'Post With Working Cover',
+          url: 'https://blog.example.com/posts/working-cover',
+          image: imageUrl,
+        });
+
+        expect(overlayGenerator).toHaveBeenLastCalledWith(
+          expect.objectContaining({ image: imageUrl }),
+          expect.any(Number),
+          expect.any(Number),
+          expect.any(Object),
+          expect.any(Object)
+        );
+        expect(result.metadata.image).toBe(imageUrl);
+      } finally {
+        templates.modern = originalTemplate;
+      }
+    });
+
+    it('falls back to a blank canvas when image processing fails', async () => {
+      const originalTemplate = templates.modern;
+      const overlayGenerator = vi.fn(
+        () => '<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" />'
+      );
+      templates.modern = { ...originalTemplate, overlayGenerator };
+      const imageUrl = 'https://cdn.example.com/covers/unprocessable.png';
+      const pngImageBuffer = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+        'base64'
+      );
+      mockedAxios.get.mockResolvedValueOnce({
+        data: pngImageBuffer,
+        headers: { 'content-type': 'image/png' },
+      });
+      const sharpInstance = mockedSharp();
+      sharpInstance.toBuffer
+        .mockResolvedValueOnce(Buffer.from('rasterized-overlay'))
+        .mockRejectedValueOnce(new Error('Resize failed'))
+        .mockResolvedValue(Buffer.from('generated-image'));
+
+      try {
+        const result = await generatePreviewFromMetadataWithDetails({
+          title: 'Post With Unprocessable Cover',
+          url: 'https://blog.example.com/posts/unprocessable-cover',
+          image: imageUrl,
+        });
+
+        expect(overlayGenerator).toHaveBeenLastCalledWith(
+          expect.objectContaining({ image: undefined }),
+          expect.any(Number),
+          expect.any(Number),
+          expect.any(Object),
+          expect.any(Object)
+        );
+        expect(result.metadata.image).toBeUndefined();
+      } finally {
+        templates.modern = originalTemplate;
+      }
+    });
+
+    it('does not treat a custom overlay error as an image processing fallback', async () => {
+      const originalTemplate = templates.modern;
+      const overlayGenerator = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error('Custom overlay failed');
+        })
+        .mockReturnValue(
+          '<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" />'
+        );
+      templates.modern = { ...originalTemplate, overlayGenerator };
+      const pngImageBuffer = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+        'base64'
+      );
+      mockedAxios.get.mockResolvedValueOnce({
+        data: pngImageBuffer,
+        headers: { 'content-type': 'image/png' },
+      });
+
+      try {
+        await expect(
+          generatePreviewFromMetadataWithDetails({
+            title: 'Post With Custom Overlay',
+            url: 'https://blog.example.com/posts/custom-overlay',
+            image: 'https://cdn.example.com/covers/custom-overlay.png',
+          })
+        ).rejects.toMatchObject({
+          type: ErrorType.IMAGE_ERROR,
+          message: expect.stringContaining('Custom overlay failed'),
+        });
+        expect(overlayGenerator).toHaveBeenCalledTimes(1);
+      } finally {
+        templates.modern = originalTemplate;
+      }
+    });
+
+    it('does not treat a malformed custom overlay as an image processing fallback', async () => {
+      const originalTemplate = templates.modern;
+      const overlayGenerator = vi
+        .fn()
+        .mockReturnValueOnce('<svg><broken></svg>')
+        .mockReturnValue(
+          '<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" />'
+        );
+      templates.modern = { ...originalTemplate, overlayGenerator };
+      const pngImageBuffer = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+        'base64'
+      );
+      mockedAxios.get.mockResolvedValueOnce({
+        data: pngImageBuffer,
+        headers: { 'content-type': 'image/png' },
+      });
+      const sharpInstance = mockedSharp();
+      sharpInstance.toBuffer
+        .mockRejectedValueOnce(new Error('XML parse error'))
+        .mockResolvedValue(Buffer.from('generated-image'));
+
+      try {
+        await expect(
+          generatePreviewFromMetadataWithDetails({
+            title: 'Post With Malformed Overlay',
+            url: 'https://blog.example.com/posts/malformed-overlay',
+            image: 'https://cdn.example.com/covers/malformed-overlay.png',
+          })
+        ).rejects.toMatchObject({
+          type: ErrorType.IMAGE_ERROR,
+          message: expect.stringContaining('XML parse error'),
+        });
+        expect(overlayGenerator).toHaveBeenCalledTimes(1);
+      } finally {
+        templates.modern = originalTemplate;
+      }
+    });
+
+    it.each(['generate', 'auto'] as const)(
+      'reports the rendered %s fallback template and metadata on misses and cache hits',
+      async (strategy) => {
+        const url = `https://${strategy}-fallback-contract.example/post`;
+        mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
+        mockedOgs.mockRejectedValueOnce(new Error('OGS error'));
+
+        const first = await generatePreviewWithDetails(url, {
+          cache: true,
+          fallback: {
+            strategy,
+            text: 'Rendered Fallback Title',
+          },
+        });
+        const second = await generatePreviewWithDetails(url, {
+          cache: true,
+          fallback: {
+            strategy,
+            text: 'Rendered Fallback Title',
+          },
+        });
+
+        expect(first).toMatchObject({
+          template: 'fallback',
+          cached: false,
+          metadata: {
+            title: 'Rendered Fallback Title',
+            url,
+            domain: `${strategy}-fallback-contract.example`,
+            siteName: `${strategy}-fallback-contract.example`,
+          },
+        });
+        expect(second).toMatchObject({
+          template: 'fallback',
+          cached: true,
+          metadata: first.metadata,
+        });
+      }
+    );
   });
 
   describe('generatePreviewFromMetadata', () => {


### PR DESCRIPTION
## Summary
- remove failed background-image URLs from the metadata actually passed to overlays and returned in details
- report the real `fallback` template and exact rendered fallback metadata on cache misses and hits
- distinguish lazy Sharp background failures from custom-overlay failures so only image failures retry on a blank canvas

## Verification
- focused render tests (3 files, 45 passed)
- `pnpm test` (25 files, 475 passed)
- `pnpm run lint`
- `pnpm exec tsc -p test/tsconfig.json --noEmit`
- `pnpm run build`
- `pnpm run verify:release -- --tag v0.2.6`
- `pnpm run verify:package`
- `git diff --check origin/master...HEAD`
- visual inspection of fallback and failed-image JPEGs at 1200x630, 3-channel sRGB

## Compatibility
Public Buffer APIs and fallback option types are unchanged. Removal of unsupported fallback option fields is intentionally excluded from this PR pending a separate breaking-change decision.