### PR TITLE
fix(network): bound outbound request lifetime

### DIFF
--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -285,14 +285,8 @@ async function extractMetadataInternal(
   return metadata;
 }
 
-/**
- * Validate and normalize URL with SSRF protection
- */
-async function validateUrl(
-  url: string,
-  securityOptions?: SecurityOptions,
-  abortSignal?: AbortSignal
-): Promise<string> {
+/** Validate cheap URL syntax and policy before consuming a network permit. */
+function validateUrlBeforeNetwork(url: string, securityOptions?: SecurityOptions): string {
   try {
     const urlObj = new URL(url);
 
@@ -306,29 +300,48 @@ async function validateUrl(
       throw new Error('HTTP URLs are not allowed when HTTPS-only mode is enabled.');
     }
 
+    return urlObj.toString();
+  } catch (error) {
+    if (error instanceof PreviewGeneratorError) {
+      throw error;
+    }
+    throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, `Invalid URL: ${url}`, error);
+  }
+}
+
+/** Perform DNS-backed SSRF validation inside the controlled request deadline. */
+async function validateUrlSecurity(
+  validatedUrl: string,
+  abortSignal: AbortSignal
+): Promise<string> {
+  try {
     // Enhanced security validation with TOCTOU protection
-    const securityValidation = await validateRequestSecurity(url, abortSignal);
+    const securityValidation = await validateRequestSecurity(validatedUrl, abortSignal);
     if (!securityValidation.allowed) {
       throw new PreviewGeneratorError(
         ErrorType.VALIDATION_ERROR,
         `URL blocked by security validation: ${securityValidation.reason}`,
-        { 
-          url, 
+        {
+          url: validatedUrl,
           blockedIPs: securityValidation.blockedIPs,
           allowedIPs: securityValidation.allowedIPs
         }
       );
     }
 
-    return urlObj.toString();
+    return validatedUrl;
   } catch (error) {
-    if (abortSignal?.aborted) {
+    if (abortSignal.aborted) {
       throw abortSignal.reason ?? error;
     }
     if (error instanceof PreviewGeneratorError) {
       throw error;
     }
-    throw new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, `Invalid URL: ${url}`, error);
+    throw new PreviewGeneratorError(
+      ErrorType.VALIDATION_ERROR,
+      `Invalid URL: ${validatedUrl}`,
+      error
+    );
   }
 }
 
@@ -340,6 +353,7 @@ async function fetchOpenGraphData(
   securityOptions?: SecurityOptions,
   abortSignal?: AbortSignal
 ): Promise<{ data: Record<string, unknown>; validatedUrl: string }> {
+  const normalizedUrl = validateUrlBeforeNetwork(url, securityOptions);
   const requestTimeout = securityOptions?.timeout || 8000;
   // Create secure axios config with redirect validation and secure agent
   const axiosConfig = {
@@ -366,7 +380,7 @@ async function fetchOpenGraphData(
       requestTimeout,
       abortSignal,
       async signal => {
-        const requestUrl = await validateUrl(url, securityOptions, signal);
+        const requestUrl = await validateUrlSecurity(normalizedUrl, signal);
         const response = await axios.get(requestUrl, { ...axiosConfig, signal });
         return { response, validatedUrl: requestUrl };
       }
@@ -524,6 +538,8 @@ function cleanText(text: string): string {
  */
 export async function fetchImage(imageUrl: string, securityOptions?: SecurityOptions, abortSignal?: AbortSignal): Promise<Buffer> {
   try {
+    const normalizedUrl = validateUrlBeforeNetwork(imageUrl, securityOptions);
+
     // Check SVG allowance
     const allowedMimeTypes = securityOptions?.allowSvg
       ? new Set([...BASE_ALLOWED_MIME_TYPES, 'image/svg+xml'])
@@ -534,7 +550,7 @@ export async function fetchImage(imageUrl: string, securityOptions?: SecurityOpt
       requestTimeout,
       abortSignal,
       async signal => {
-        const validatedUrl = await validateUrl(imageUrl, securityOptions, signal);
+        const validatedUrl = await validateUrlSecurity(normalizedUrl, signal);
         return axios.get(validatedUrl, {
           responseType: 'arraybuffer',
           headers: {

--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -17,6 +17,12 @@ import { metadataCache } from '../utils/cache';
 import { logger } from '../utils/logger';
 import { MAX_TEXT_LENGTH } from '../constants/security';
 import { truncateText } from '../utils/validators/text';
+import {
+  NetworkRequestAbortedError,
+  NetworkRequestDeadlineError,
+  NetworkRequestQueueFullError,
+  runControlledNetworkRequest,
+} from '../utils/network-request-control';
 
 // Allowed MIME types for images
 const BASE_ALLOWED_MIME_TYPES = new Set([
@@ -31,6 +37,17 @@ const BASE_ALLOWED_MIME_TYPES = new Set([
 
 // Maximum allowed image size (15MB)
 const MAX_IMAGE_SIZE = 15 * 1024 * 1024;
+
+function getNetworkControlErrorMessage(error: unknown): string | undefined {
+  if (
+    error instanceof NetworkRequestAbortedError ||
+    error instanceof NetworkRequestDeadlineError ||
+    error instanceof NetworkRequestQueueFullError
+  ) {
+    return error.message;
+  }
+  return undefined;
+}
 
 /**
  * Build redirect validation callback for SSRF protection
@@ -311,6 +328,7 @@ async function validateUrl(url: string, securityOptions?: SecurityOptions): Prom
  * Fetch Open Graph data using open-graph-scraper
  */
 async function fetchOpenGraphData(url: string, securityOptions?: SecurityOptions, abortSignal?: AbortSignal): Promise<Record<string, unknown>> {
+  const requestTimeout = securityOptions?.timeout || 8000;
   // Create secure axios config with redirect validation and secure agent
   const axiosConfig = {
     headers: {
@@ -318,21 +336,24 @@ async function fetchOpenGraphData(url: string, securityOptions?: SecurityOptions
       Accept: 'text/html,application/xhtml+xml',
     },
     responseType: 'text' as const,
-    timeout: securityOptions?.timeout || 8000,
+    timeout: requestTimeout,
     maxRedirects: securityOptions?.maxRedirects ?? 3,
     maxContentLength: 1 * 1024 * 1024,
     maxBodyLength: 1 * 1024 * 1024,
     httpAgent: getEnhancedSecureHttpAgent(),
     httpsAgent: getEnhancedSecureHttpsAgent(),
     proxy: false as const,
-    signal: abortSignal,
     beforeRedirect: createRedirectValidator('Redirect', securityOptions?.httpsOnly === true),
   };
 
   // Phase 1: Fetch HTML through secure agent
   let html: string;
   try {
-    const response = await axios.get(url, axiosConfig);
+    const response = await runControlledNetworkRequest(
+      requestTimeout,
+      abortSignal,
+      signal => axios.get(url, { ...axiosConfig, signal })
+    );
 
     if (typeof response.data !== 'string') {
       throw new Error('Expected HTML response but received non-string data');
@@ -341,9 +362,10 @@ async function fetchOpenGraphData(url: string, securityOptions?: SecurityOptions
     html = response.data;
   } catch (fetchError) {
     // Network-level failure — no HTML to parse, fail immediately without retry
+    const controlMessage = getNetworkControlErrorMessage(fetchError);
     throw new PreviewGeneratorError(
       ErrorType.FETCH_ERROR,
-      `Failed to fetch data from ${url}`,
+      `Failed to fetch data from ${url}${controlMessage ? `: ${controlMessage}` : ''}`,
       fetchError
     );
   }
@@ -486,24 +508,29 @@ export async function fetchImage(imageUrl: string, securityOptions?: SecurityOpt
       ? new Set([...BASE_ALLOWED_MIME_TYPES, 'image/svg+xml'])
       : BASE_ALLOWED_MIME_TYPES;
 
-    const response = await axios.get(validatedUrl, {
-      responseType: 'arraybuffer',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; SocialPreviewBot/1.0)',
-      },
-      timeout: securityOptions?.timeout || 12000, // Configurable timeout (default 12s for images)
-      maxRedirects: securityOptions?.maxRedirects ?? 3, // Configurable redirects
-      maxContentLength: MAX_IMAGE_SIZE,
-      maxBodyLength: MAX_IMAGE_SIZE,
-      httpAgent: getEnhancedSecureHttpAgent(),
-      httpsAgent: getEnhancedSecureHttpsAgent(),
-      proxy: false,
-      signal: abortSignal, // Add abort signal for request cancellation
-      beforeRedirect: createRedirectValidator(
-        'Image redirect',
-        securityOptions?.httpsOnly === true
-      ),
-    });
+    const requestTimeout = securityOptions?.timeout || 12000;
+    const response = await runControlledNetworkRequest(
+      requestTimeout,
+      abortSignal,
+      signal => axios.get(validatedUrl, {
+        responseType: 'arraybuffer',
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; SocialPreviewBot/1.0)',
+        },
+        timeout: requestTimeout, // Socket inactivity timeout; the wrapper also enforces a total deadline.
+        maxRedirects: securityOptions?.maxRedirects ?? 3, // Configurable redirects
+        maxContentLength: MAX_IMAGE_SIZE,
+        maxBodyLength: MAX_IMAGE_SIZE,
+        httpAgent: getEnhancedSecureHttpAgent(),
+        httpsAgent: getEnhancedSecureHttpsAgent(),
+        proxy: false,
+        signal,
+        beforeRedirect: createRedirectValidator(
+          'Image redirect',
+          securityOptions?.httpsOnly === true
+        ),
+      })
+    );
 
     // Check content-type header if available (extract base MIME type, ignoring charset etc.)
     const contentTypeHeader = response.headers?.['content-type'];

--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -269,11 +269,12 @@ async function extractMetadataInternal(
   securityOptions?: SecurityOptions,
   abortSignal?: AbortSignal
 ): Promise<ExtractedMetadata> {
-  // Validate URL with SSRF protection and security options
-  const validatedUrl = await validateUrl(url, securityOptions);
-
-  // Extract Open Graph data
-  const ogData = await fetchOpenGraphData(validatedUrl, securityOptions, abortSignal);
+  // DNS validation and the HTTP response share one total request deadline.
+  const { data: ogData, validatedUrl } = await fetchOpenGraphData(
+    url,
+    securityOptions,
+    abortSignal
+  );
 
   // Parse and normalize metadata
   const metadata = parseMetadata(ogData, validatedUrl);
@@ -287,7 +288,11 @@ async function extractMetadataInternal(
 /**
  * Validate and normalize URL with SSRF protection
  */
-async function validateUrl(url: string, securityOptions?: SecurityOptions): Promise<string> {
+async function validateUrl(
+  url: string,
+  securityOptions?: SecurityOptions,
+  abortSignal?: AbortSignal
+): Promise<string> {
   try {
     const urlObj = new URL(url);
 
@@ -302,7 +307,7 @@ async function validateUrl(url: string, securityOptions?: SecurityOptions): Prom
     }
 
     // Enhanced security validation with TOCTOU protection
-    const securityValidation = await validateRequestSecurity(url);
+    const securityValidation = await validateRequestSecurity(url, abortSignal);
     if (!securityValidation.allowed) {
       throw new PreviewGeneratorError(
         ErrorType.VALIDATION_ERROR,
@@ -317,6 +322,9 @@ async function validateUrl(url: string, securityOptions?: SecurityOptions): Prom
 
     return urlObj.toString();
   } catch (error) {
+    if (abortSignal?.aborted) {
+      throw abortSignal.reason ?? error;
+    }
     if (error instanceof PreviewGeneratorError) {
       throw error;
     }
@@ -327,7 +335,11 @@ async function validateUrl(url: string, securityOptions?: SecurityOptions): Prom
 /**
  * Fetch Open Graph data using open-graph-scraper
  */
-async function fetchOpenGraphData(url: string, securityOptions?: SecurityOptions, abortSignal?: AbortSignal): Promise<Record<string, unknown>> {
+async function fetchOpenGraphData(
+  url: string,
+  securityOptions?: SecurityOptions,
+  abortSignal?: AbortSignal
+): Promise<{ data: Record<string, unknown>; validatedUrl: string }> {
   const requestTimeout = securityOptions?.timeout || 8000;
   // Create secure axios config with redirect validation and secure agent
   const axiosConfig = {
@@ -348,19 +360,31 @@ async function fetchOpenGraphData(url: string, securityOptions?: SecurityOptions
 
   // Phase 1: Fetch HTML through secure agent
   let html: string;
+  let validatedUrl: string;
   try {
-    const response = await runControlledNetworkRequest(
+    const fetched = await runControlledNetworkRequest(
       requestTimeout,
       abortSignal,
-      signal => axios.get(url, { ...axiosConfig, signal })
+      async signal => {
+        const requestUrl = await validateUrl(url, securityOptions, signal);
+        const response = await axios.get(requestUrl, { ...axiosConfig, signal });
+        return { response, validatedUrl: requestUrl };
+      }
     );
 
-    if (typeof response.data !== 'string') {
+    if (typeof fetched.response.data !== 'string') {
       throw new Error('Expected HTML response but received non-string data');
     }
 
-    html = response.data;
+    html = fetched.response.data;
+    validatedUrl = fetched.validatedUrl;
   } catch (fetchError) {
+    if (
+      fetchError instanceof PreviewGeneratorError &&
+      fetchError.type === ErrorType.VALIDATION_ERROR
+    ) {
+      throw fetchError;
+    }
     // Network-level failure — no HTML to parse, fail immediately without retry
     const controlMessage = getNetworkControlErrorMessage(fetchError);
     throw new PreviewGeneratorError(
@@ -379,7 +403,7 @@ async function fetchOpenGraphData(url: string, securityOptions?: SecurityOptions
       throw new Error('Failed to parse Open Graph data');
     }
 
-    return result;
+    return { data: result, validatedUrl };
   } catch (parseError) {
     throw new PreviewGeneratorError(
       ErrorType.FETCH_ERROR,
@@ -500,9 +524,6 @@ function cleanText(text: string): string {
  */
 export async function fetchImage(imageUrl: string, securityOptions?: SecurityOptions, abortSignal?: AbortSignal): Promise<Buffer> {
   try {
-    // Validate URL with SSRF protection before fetching
-    const validatedUrl = await validateUrl(imageUrl, securityOptions);
-
     // Check SVG allowance
     const allowedMimeTypes = securityOptions?.allowSvg
       ? new Set([...BASE_ALLOWED_MIME_TYPES, 'image/svg+xml'])
@@ -512,24 +533,27 @@ export async function fetchImage(imageUrl: string, securityOptions?: SecurityOpt
     const response = await runControlledNetworkRequest(
       requestTimeout,
       abortSignal,
-      signal => axios.get(validatedUrl, {
-        responseType: 'arraybuffer',
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (compatible; SocialPreviewBot/1.0)',
-        },
-        timeout: requestTimeout, // Socket inactivity timeout; the wrapper also enforces a total deadline.
-        maxRedirects: securityOptions?.maxRedirects ?? 3, // Configurable redirects
-        maxContentLength: MAX_IMAGE_SIZE,
-        maxBodyLength: MAX_IMAGE_SIZE,
-        httpAgent: getEnhancedSecureHttpAgent(),
-        httpsAgent: getEnhancedSecureHttpsAgent(),
-        proxy: false,
-        signal,
-        beforeRedirect: createRedirectValidator(
-          'Image redirect',
-          securityOptions?.httpsOnly === true
-        ),
-      })
+      async signal => {
+        const validatedUrl = await validateUrl(imageUrl, securityOptions, signal);
+        return axios.get(validatedUrl, {
+          responseType: 'arraybuffer',
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (compatible; SocialPreviewBot/1.0)',
+          },
+          timeout: requestTimeout, // Socket inactivity timeout; the wrapper also enforces a total deadline.
+          maxRedirects: securityOptions?.maxRedirects ?? 3, // Configurable redirects
+          maxContentLength: MAX_IMAGE_SIZE,
+          maxBodyLength: MAX_IMAGE_SIZE,
+          httpAgent: getEnhancedSecureHttpAgent(),
+          httpsAgent: getEnhancedSecureHttpsAgent(),
+          proxy: false,
+          signal,
+          beforeRedirect: createRedirectValidator(
+            'Image redirect',
+            securityOptions?.httpsOnly === true
+          ),
+        });
+      }
     );
 
     // Check content-type header if available (extract base MIME type, ignoring charset etc.)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,7 @@ export interface SecurityOptions {
   allowSvg?: boolean;
   /** Maximum allowed redirects (default: 3) */
   maxRedirects?: number;
-  /** Request timeout in milliseconds (default: 8000 for HTML, 12000 for images) */
+  /** Request timeout in milliseconds, integer 1-30000 (default: 8000 for HTML, 12000 for images) */
   timeout?: number;
 }
 

--- a/src/utils/enhanced-secure-agent.ts
+++ b/src/utils/enhanced-secure-agent.ts
@@ -28,6 +28,167 @@ interface SecurityValidationResult {
   reason?: string;
 }
 
+const MAX_ACTIVE_DNS_LOOKUPS = 8;
+const MAX_QUEUED_DNS_LOOKUPS = 1000;
+const DNS_LOOKUP_TIMEOUT_MS = SECURITY_CONFIG.HTTP_TIMEOUT;
+
+type ReleaseDNSLookupPermit = () => void;
+
+interface DNSLookupQueueEntry {
+  signal: AbortSignal;
+  resolve: (release: ReleaseDNSLookupPermit) => void;
+  reject: (error: unknown) => void;
+  onAbort: () => void;
+}
+
+let activeDNSLookups = 0;
+const dnsLookupQueue: DNSLookupQueueEntry[] = [];
+
+function createDNSLookupError(message: string, code: string): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = code;
+  error.syscall = 'getaddrinfo';
+  return error;
+}
+
+function getDNSLookupAbortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? createDNSLookupError('DNS lookup aborted', 'ABORT_ERR');
+}
+
+function createDNSLookupReleasePermit(): ReleaseDNSLookupPermit {
+  let released = false;
+
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    activeDNSLookups = Math.max(0, activeDNSLookups - 1);
+    drainDNSLookupQueue();
+  };
+}
+
+function grantDNSLookupPermit(entry: DNSLookupQueueEntry): boolean {
+  entry.signal.removeEventListener('abort', entry.onAbort);
+  if (entry.signal.aborted) {
+    entry.reject(getDNSLookupAbortReason(entry.signal));
+    return false;
+  }
+
+  activeDNSLookups += 1;
+  entry.resolve(createDNSLookupReleasePermit());
+  return true;
+}
+
+function drainDNSLookupQueue(): void {
+  while (activeDNSLookups < MAX_ACTIVE_DNS_LOOKUPS && dnsLookupQueue.length > 0) {
+    const entry = dnsLookupQueue.shift();
+    if (entry) {
+      grantDNSLookupPermit(entry);
+    }
+  }
+}
+
+function acquireDNSLookupPermit(signal: AbortSignal): Promise<ReleaseDNSLookupPermit> {
+  if (signal.aborted) {
+    return Promise.reject(getDNSLookupAbortReason(signal));
+  }
+
+  if (activeDNSLookups < MAX_ACTIVE_DNS_LOOKUPS && dnsLookupQueue.length === 0) {
+    activeDNSLookups += 1;
+    return Promise.resolve(createDNSLookupReleasePermit());
+  }
+
+  if (dnsLookupQueue.length >= MAX_QUEUED_DNS_LOOKUPS) {
+    return Promise.reject(
+      createDNSLookupError(
+        `DNS lookup queue limit reached (${MAX_QUEUED_DNS_LOOKUPS}). Server is busy, please try again later.`,
+        'EAI_AGAIN'
+      )
+    );
+  }
+
+  return new Promise<ReleaseDNSLookupPermit>((resolve, reject) => {
+    const entry: DNSLookupQueueEntry = {
+      signal,
+      resolve,
+      reject,
+      onAbort: () => {
+        const index = dnsLookupQueue.indexOf(entry);
+        if (index !== -1) {
+          dnsLookupQueue.splice(index, 1);
+        }
+        signal.removeEventListener('abort', entry.onAbort);
+        reject(getDNSLookupAbortReason(signal));
+      },
+    };
+
+    dnsLookupQueue.push(entry);
+    signal.addEventListener('abort', entry.onAbort, { once: true });
+    drainDNSLookupQueue();
+  });
+}
+
+interface DNSLookupAbortContext {
+  signal: AbortSignal;
+  aborted: Promise<never>;
+  cleanup: () => void;
+}
+
+function createDNSLookupAbortContext(callerSignal?: AbortSignal): DNSLookupAbortContext {
+  const controller = new AbortController();
+  const abort = (error: unknown) => {
+    if (!controller.signal.aborted) {
+      controller.abort(error);
+    }
+  };
+  const onCallerAbort = () => {
+    abort(callerSignal?.reason ?? createDNSLookupError('DNS lookup aborted', 'ABORT_ERR'));
+  };
+
+  if (callerSignal?.aborted) {
+    onCallerAbort();
+  } else {
+    callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
+  }
+
+  const timeoutId = controller.signal.aborted
+    ? undefined
+    : setTimeout(() => {
+        abort(
+          createDNSLookupError(
+            `DNS lookup timed out after ${DNS_LOOKUP_TIMEOUT_MS}ms`,
+            'EAI_AGAIN'
+          )
+        );
+      }, DNS_LOOKUP_TIMEOUT_MS);
+  timeoutId?.unref?.();
+
+  const aborted = new Promise<never>((_, reject) => {
+    if (controller.signal.aborted) {
+      reject(getDNSLookupAbortReason(controller.signal));
+      return;
+    }
+
+    controller.signal.addEventListener(
+      'abort',
+      () => reject(getDNSLookupAbortReason(controller.signal)),
+      { once: true }
+    );
+  });
+
+  return {
+    signal: controller.signal,
+    aborted,
+    cleanup: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      callerSignal?.removeEventListener('abort', onCallerAbort);
+    },
+  };
+}
+
 /**
  * DNS Cache with TTL support
  * Prevents TOCTOU attacks by ensuring consistent IP resolution
@@ -48,17 +209,58 @@ class SecureDNSCache {
   /**
    * Get cached DNS result or perform fresh lookup
    */
-  async lookup(hostname: string): Promise<dns.LookupAddress[]> {
+  async lookup(hostname: string, callerSignal?: AbortSignal): Promise<dns.LookupAddress[]> {
     const cacheKey = hostname.toLowerCase();
     const cached = this.cache.get(cacheKey);
     const now = Date.now();
+
+    if (callerSignal?.aborted) {
+      throw callerSignal.reason ?? createDNSLookupError('DNS lookup aborted', 'ABORT_ERR');
+    }
 
     // Return cached result if valid
     if (cached && now - cached.timestamp < cached.ttl) {
       return cached.addresses;
     }
 
-    // Perform fresh DNS lookup
+    const abortContext = createDNSLookupAbortContext(callerSignal);
+    const controlledLookup = (async () => {
+      const release = await acquireDNSLookupPermit(abortContext.signal);
+      let nativeLookupStarted = false;
+
+      try {
+        if (abortContext.signal.aborted) {
+          throw getDNSLookupAbortReason(abortContext.signal);
+        }
+
+        // A prior queued lookup may have populated the cache while this caller waited.
+        const queuedCached = this.cache.get(cacheKey);
+        const queuedNow = Date.now();
+        if (queuedCached && queuedNow - queuedCached.timestamp < queuedCached.ttl) {
+          return queuedCached.addresses;
+        }
+
+        const nativeLookup = this.performFreshLookup(hostname, cacheKey);
+        nativeLookupStarted = true;
+
+        // dns.lookup cannot be cancelled. Keep the permit until its callback settles,
+        // even if the caller's deadline or AbortSignal wins the outer race.
+        return await nativeLookup.finally(release);
+      } finally {
+        if (!nativeLookupStarted) {
+          release();
+        }
+      }
+    })();
+
+    try {
+      return await Promise.race([controlledLookup, abortContext.aborted]);
+    } finally {
+      abortContext.cleanup();
+    }
+  }
+
+  private performFreshLookup(hostname: string, cacheKey: string): Promise<dns.LookupAddress[]> {
     return new Promise((resolve, reject) => {
       const lookupOptions: dns.LookupAllOptions = {
         all: true,
@@ -79,7 +281,7 @@ class SecureDNSCache {
         // Cache the result
         const cacheEntry: CachedDNSResult = {
           addresses: addressList,
-          timestamp: now,
+          timestamp: Date.now(),
           ttl: this.defaultTTL,
           hostname
         };
@@ -544,13 +746,16 @@ export function invalidateDNSCache(hostname?: string) {
 /**
  * Advanced security validation for HTTP requests
  */
-export async function validateRequestSecurity(url: string): Promise<SecurityValidationResult> {
+export async function validateRequestSecurity(
+  url: string,
+  abortSignal?: AbortSignal
+): Promise<SecurityValidationResult> {
   try {
     const urlObj = new URL(url);
     const hostname = urlObj.hostname;
 
     // Perform DNS lookup and validation
-    const addresses = await dnsCache.lookup(hostname);
+    const addresses = await dnsCache.lookup(hostname, abortSignal);
     const validation = validateIPAddresses(addresses);
 
     if (!validation.allowed) {
@@ -564,6 +769,9 @@ export async function validateRequestSecurity(url: string): Promise<SecurityVali
 
     return validation;
   } catch (error) {
+    if (abortSignal?.aborted) {
+      throw abortSignal.reason ?? error;
+    }
     logger.error('Security validation failed', { url, error: error as Error });
     return {
       allowed: false,
@@ -573,6 +781,19 @@ export async function validateRequestSecurity(url: string): Promise<SecurityVali
     };
   }
 }
+
+/** Test-only visibility for deterministic DNS admission-control assertions. */
+export const __testDNSLookupLimiter = process.env.NODE_ENV === 'test'
+  ? {
+      getStats: () => ({
+        active: activeDNSLookups,
+        queued: dnsLookupQueue.length,
+        activeLimit: MAX_ACTIVE_DNS_LOOKUPS,
+        queuedLimit: MAX_QUEUED_DNS_LOOKUPS,
+        timeoutMs: DNS_LOOKUP_TIMEOUT_MS,
+      }),
+    }
+  : undefined;
 
 // Export cleanup function for application-level resource management
 // Applications should call this during graceful shutdown

--- a/src/utils/network-request-control.ts
+++ b/src/utils/network-request-control.ts
@@ -1,0 +1,240 @@
+/**
+ * Process-wide controls for outbound HTML and image requests.
+ *
+ * The secure HTTP agents bound sockets per origin. This limiter adds a global
+ * ceiling so callers cannot bypass the bound by spreading requests over many
+ * different origins. The deadline is intentionally separate from Axios'
+ * socket-inactivity timeout and covers queue wait plus the complete response.
+ */
+
+const MAX_ACTIVE_REQUESTS = 50;
+const MAX_QUEUED_REQUESTS = 1000;
+
+type ReleasePermit = () => void;
+
+interface QueueEntry {
+  generation: number;
+  signal: AbortSignal;
+  resolve: (release: ReleasePermit) => void;
+  reject: (error: unknown) => void;
+  onAbort: () => void;
+}
+
+let activeRequests = 0;
+let limiterGeneration = 0;
+const requestQueue: QueueEntry[] = [];
+
+export class NetworkRequestDeadlineError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`Network request deadline exceeded after ${timeoutMs}ms`);
+    this.name = 'NetworkRequestDeadlineError';
+  }
+}
+
+export class NetworkRequestAbortedError extends Error {
+  constructor(message: string = 'Network request aborted by caller') {
+    super(message);
+    this.name = 'NetworkRequestAbortedError';
+  }
+}
+
+export class NetworkRequestQueueFullError extends Error {
+  constructor() {
+    super(
+      `Network request queue limit reached (${MAX_QUEUED_REQUESTS}). Server is busy, please try again later.`
+    );
+    this.name = 'NetworkRequestQueueFullError';
+  }
+}
+
+function signalReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new NetworkRequestAbortedError();
+}
+
+function createReleasePermit(generation: number): ReleasePermit {
+  let released = false;
+
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+
+    // A test-only reset invalidates permits from the previous generation.
+    if (generation !== limiterGeneration) {
+      return;
+    }
+
+    activeRequests = Math.max(0, activeRequests - 1);
+    drainQueue();
+  };
+}
+
+function grantPermit(entry: QueueEntry): boolean {
+  entry.signal.removeEventListener('abort', entry.onAbort);
+  if (entry.signal.aborted || entry.generation !== limiterGeneration) {
+    entry.reject(signalReason(entry.signal));
+    return false;
+  }
+
+  activeRequests += 1;
+  entry.resolve(createReleasePermit(entry.generation));
+  return true;
+}
+
+function drainQueue(): void {
+  while (activeRequests < MAX_ACTIVE_REQUESTS && requestQueue.length > 0) {
+    const entry = requestQueue.shift();
+    if (entry && grantPermit(entry)) {
+      // Continue while capacity remains, preserving FIFO order.
+      continue;
+    }
+  }
+}
+
+function acquirePermit(signal: AbortSignal): Promise<ReleasePermit> {
+  if (signal.aborted) {
+    return Promise.reject(signalReason(signal));
+  }
+
+  const generation = limiterGeneration;
+  if (activeRequests < MAX_ACTIVE_REQUESTS && requestQueue.length === 0) {
+    activeRequests += 1;
+    return Promise.resolve(createReleasePermit(generation));
+  }
+
+  if (requestQueue.length >= MAX_QUEUED_REQUESTS) {
+    return Promise.reject(new NetworkRequestQueueFullError());
+  }
+
+  return new Promise<ReleasePermit>((resolve, reject) => {
+    const entry: QueueEntry = {
+      generation,
+      signal,
+      resolve,
+      reject,
+      onAbort: () => {
+        const index = requestQueue.indexOf(entry);
+        if (index !== -1) {
+          requestQueue.splice(index, 1);
+        }
+        signal.removeEventListener('abort', entry.onAbort);
+        reject(signalReason(signal));
+      },
+    };
+
+    requestQueue.push(entry);
+    signal.addEventListener('abort', entry.onAbort, { once: true });
+  });
+}
+
+interface RequestAbortContext {
+  signal: AbortSignal;
+  aborted: Promise<never>;
+  cleanup: () => void;
+}
+
+function createRequestAbortContext(
+  timeoutMs: number,
+  callerSignal?: AbortSignal
+): RequestAbortContext {
+  const controller = new AbortController();
+  let rejectAborted!: (error: unknown) => void;
+  const aborted = new Promise<never>((_, reject) => {
+    rejectAborted = reject;
+  });
+
+  const abort = (reason: unknown) => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    controller.abort(reason);
+    rejectAborted(reason);
+  };
+
+  const onCallerAbort = () => {
+    abort(new NetworkRequestAbortedError());
+  };
+
+  if (callerSignal?.aborted) {
+    onCallerAbort();
+  } else {
+    callerSignal?.addEventListener('abort', onCallerAbort, { once: true });
+  }
+
+  const timeoutId = controller.signal.aborted
+    ? undefined
+    : setTimeout(() => {
+        abort(new NetworkRequestDeadlineError(timeoutMs));
+      }, timeoutMs);
+  timeoutId?.unref?.();
+
+  return {
+    signal: controller.signal,
+    aborted,
+    cleanup: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      callerSignal?.removeEventListener('abort', onCallerAbort);
+    },
+  };
+}
+
+/**
+ * Run one outbound request under a total wall-clock deadline and the shared
+ * process-wide concurrency limit.
+ */
+export async function runControlledNetworkRequest<T>(
+  timeoutMs: number,
+  callerSignal: AbortSignal | undefined,
+  request: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const abortContext = createRequestAbortContext(timeoutMs, callerSignal);
+  const controlledRequest = (async () => {
+    const release = await acquirePermit(abortContext.signal);
+    try {
+      abortContext.signal.throwIfAborted();
+      // Race inside the permit boundary as well. This returns capacity on
+      // abort even if a transport mock ignores AbortSignal and never settles.
+      return await Promise.race([
+        request(abortContext.signal),
+        abortContext.aborted,
+      ]);
+    } finally {
+      release();
+    }
+  })();
+
+  try {
+    // The explicit abort race guarantees prompt settlement even if a mocked or
+    // non-compliant transport ignores AbortSignal. Axios still receives the
+    // same signal and cancels the real socket/body stream.
+    return await Promise.race([controlledRequest, abortContext.aborted]);
+  } finally {
+    abortContext.cleanup();
+  }
+}
+
+function resetLimiterForTests(): void {
+  limiterGeneration += 1;
+  activeRequests = 0;
+  const resetError = new NetworkRequestAbortedError('Network request limiter reset for test');
+  for (const entry of requestQueue.splice(0)) {
+    entry.signal.removeEventListener('abort', entry.onAbort);
+    entry.reject(resetError);
+  }
+}
+
+/** Test-only limiter visibility; omitted at runtime outside NODE_ENV=test. */
+export const __testNetworkRequestLimiter = process.env.NODE_ENV === 'test'
+  ? {
+      getStats: () => ({
+        active: activeRequests,
+        queued: requestQueue.length,
+        activeLimit: MAX_ACTIVE_REQUESTS,
+        queuedLimit: MAX_QUEUED_REQUESTS,
+      }),
+      reset: resetLimiterForTests,
+    }
+  : undefined;

--- a/src/utils/network-request-control.ts
+++ b/src/utils/network-request-control.ts
@@ -153,7 +153,7 @@ function createRequestAbortContext(
   };
 
   const onCallerAbort = () => {
-    abort(new NetworkRequestAbortedError());
+    abort(signalReason(callerSignal!));
   };
 
   if (callerSignal?.aborted) {

--- a/src/utils/network-request-control.ts
+++ b/src/utils/network-request-control.ts
@@ -148,8 +148,12 @@ function createRequestAbortContext(
     if (controller.signal.aborted) {
       return;
     }
-    controller.abort(reason);
+    // Settle the controlled reason before dispatching AbortSignal listeners.
+    // Transports such as Axios may synchronously reject with a generic
+    // cancellation error from their listener; that must not mask the caller's
+    // reason or this deadline error in the surrounding Promise.race.
     rejectAborted(reason);
+    controller.abort(reason);
   };
 
   const onCallerAbort = () => {

--- a/src/utils/validators/options.ts
+++ b/src/utils/validators/options.ts
@@ -8,6 +8,9 @@ import { validateColor } from './color';
 import { validateDimension, validateDimensions } from './dimensions';
 import { validateTextInput } from './text';
 
+const MIN_REQUEST_TIMEOUT_MS = 1;
+const MAX_REQUEST_TIMEOUT_MS = 30_000;
+
 /**
  * Validates all preview options including dimensions, quality, and colors.
  */
@@ -115,6 +118,29 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
       throw new PreviewGeneratorError(
         ErrorType.VALIDATION_ERROR,
         `Quality must be between ${QUALITY_LIMITS.MIN} and ${QUALITY_LIMITS.MAX}`
+      );
+    }
+  }
+
+  // Bound the total request deadline so invalid timer values cannot disable or
+  // unexpectedly truncate outbound-request protection.
+  if (sanitized.security?.timeout !== undefined) {
+    const timeout = sanitized.security.timeout;
+    if (
+      typeof timeout !== 'number' ||
+      !Number.isFinite(timeout) ||
+      !Number.isInteger(timeout)
+    ) {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        'Security timeout must be a finite integer in milliseconds'
+      );
+    }
+
+    if (timeout < MIN_REQUEST_TIMEOUT_MS || timeout > MAX_REQUEST_TIMEOUT_MS) {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        `Security timeout must be between ${MIN_REQUEST_TIMEOUT_MS} and ${MAX_REQUEST_TIMEOUT_MS} milliseconds`
       );
     }
   }

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -517,6 +517,21 @@ describe('End-to-End Integration Tests', () => {
         });
       }
     );
+
+    it.each([NaN, Infinity, 0, 30_001])(
+      'should reject unsafe public security timeout %s before network I/O',
+      async timeout => {
+        await expect(
+          generatePreview('https://timeout-validation.example', {
+            security: { timeout },
+          })
+        ).rejects.toMatchObject({
+          type: ErrorType.VALIDATION_ERROR,
+          message: expect.stringContaining('Security timeout'),
+        });
+        expect(mockedAxios.get).not.toHaveBeenCalled();
+      }
+    );
   });
 
   describe('generatePreviewFromMetadata', () => {

--- a/test/unit/dns-network-deadline.test.ts
+++ b/test/unit/dns-network-deadline.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   __testNetworkRequestLimiter,
   NetworkRequestDeadlineError,
+  runControlledNetworkRequest,
 } from '../../src/utils/network-request-control';
 import { ErrorType, PreviewGeneratorError } from '../../src/types';
 
@@ -57,6 +58,14 @@ function deferNativeDNSLookup() {
       pendingCallback(error, []);
     },
   };
+}
+
+function deferredWork() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 async function flushAsyncWork(): Promise<void> {
@@ -157,6 +166,35 @@ describe('DNS preflight network deadline composition', () => {
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       deferredDNS.rejectForCleanup();
+    }
+  });
+
+  it('rejects a non-HTTP URL without entering a saturated request queue', async () => {
+    (dns.lookup as any) = vi.fn();
+    const activeWork = Array.from({ length: 50 }, deferredWork);
+    const activeRequests = activeWork.map(work =>
+      runControlledNetworkRequest(60_000, undefined, async () => work.promise)
+    );
+    const invalidRequest = extractMetadata('ftp://invalid.example/resource');
+    const capturedError = invalidRequest.then(
+      () => undefined,
+      error => error as PreviewGeneratorError
+    );
+
+    try {
+      await flushAsyncWork();
+      expect(__testNetworkRequestLimiter!.getStats()).toMatchObject({ active: 50, queued: 0 });
+
+      const error = await capturedError;
+      expect(error).toMatchObject({ type: ErrorType.VALIDATION_ERROR });
+      expect(dns.lookup).not.toHaveBeenCalled();
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    } finally {
+      for (const work of activeWork) {
+        work.resolve();
+      }
+      await Promise.allSettled(activeRequests);
+      await capturedError;
     }
   });
 });

--- a/test/unit/dns-network-deadline.test.ts
+++ b/test/unit/dns-network-deadline.test.ts
@@ -1,0 +1,162 @@
+import dns from 'dns';
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearInflightRequests,
+  extractMetadata,
+  fetchImage,
+} from '../../src/core/metadata-extractor';
+import {
+  __testDNSLookupLimiter,
+  invalidateDNSCache,
+} from '../../src/utils/enhanced-secure-agent';
+import {
+  __testNetworkRequestLimiter,
+  NetworkRequestDeadlineError,
+} from '../../src/utils/network-request-control';
+import { ErrorType, PreviewGeneratorError } from '../../src/types';
+
+vi.mock('axios');
+
+const mockedAxios = vi.mocked(axios);
+const originalDNSLookup = dns.lookup;
+
+type DNSLookupCallback = (
+  error: NodeJS.ErrnoException | null,
+  addresses: dns.LookupAddress[]
+) => void;
+
+function deferNativeDNSLookup() {
+  let callback: DNSLookupCallback | undefined;
+
+  (dns.lookup as any) = vi.fn((
+    _hostname: string,
+    _options: unknown,
+    lookupCallback: DNSLookupCallback
+  ) => {
+    callback = lookupCallback;
+  });
+
+  return {
+    resolve() {
+      if (!callback) {
+        throw new Error('Native DNS lookup did not start');
+      }
+      const pendingCallback = callback;
+      callback = undefined;
+      pendingCallback(null, [{ address: '8.8.8.8', family: 4 }]);
+    },
+    rejectForCleanup() {
+      if (!callback) {
+        return;
+      }
+      const pendingCallback = callback;
+      callback = undefined;
+      const error = new Error('test cleanup') as NodeJS.ErrnoException;
+      error.code = 'ENOTFOUND';
+      pendingCallback(error, []);
+    },
+  };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('DNS preflight network deadline composition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    invalidateDNSCache();
+    clearInflightRequests();
+    __testNetworkRequestLimiter!.reset();
+  });
+
+  afterEach(() => {
+    dns.lookup = originalDNSLookup;
+    invalidateDNSCache();
+    clearInflightRequests();
+    __testNetworkRequestLimiter!.reset();
+    vi.useRealTimers();
+  });
+
+  it('bounds HTML DNS preflight with the same total deadline and performs no Axios I/O', async () => {
+    const deferredDNS = deferNativeDNSLookup();
+
+    try {
+      const request = extractMetadata('https://pending-html-dns.example', { timeout: 50 });
+      const capturedError = request.then(
+        () => undefined,
+        error => error as PreviewGeneratorError
+      );
+
+      await flushAsyncWork();
+      expect(dns.lookup).toHaveBeenCalledOnce();
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(__testNetworkRequestLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+
+      await vi.advanceTimersByTimeAsync(50);
+      const error = await capturedError;
+
+      expect(error).toMatchObject({
+        type: ErrorType.FETCH_ERROR,
+        message: expect.stringContaining('Network request deadline exceeded after 50ms'),
+        details: expect.any(NetworkRequestDeadlineError),
+      });
+      expect(error?.type).not.toBe(ErrorType.VALIDATION_ERROR);
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(__testNetworkRequestLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 });
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+
+      deferredDNS.resolve();
+      await flushAsyncWork();
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      deferredDNS.rejectForCleanup();
+    }
+  });
+
+  it('bounds image DNS preflight with the same total deadline and performs no Axios I/O', async () => {
+    const deferredDNS = deferNativeDNSLookup();
+
+    try {
+      const request = fetchImage('https://pending-image-dns.example/image.jpg', {
+        timeout: 50,
+      });
+      const capturedError = request.then(
+        () => undefined,
+        error => error as PreviewGeneratorError
+      );
+
+      await flushAsyncWork();
+      expect(dns.lookup).toHaveBeenCalledOnce();
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(__testNetworkRequestLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+
+      await vi.advanceTimersByTimeAsync(50);
+      const error = await capturedError;
+
+      expect(error).toMatchObject({
+        type: ErrorType.IMAGE_ERROR,
+        message: expect.stringContaining('Network request deadline exceeded after 50ms'),
+        details: expect.any(NetworkRequestDeadlineError),
+      });
+      expect(error?.type).not.toBe(ErrorType.VALIDATION_ERROR);
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+      expect(__testNetworkRequestLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 });
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+
+      deferredDNS.resolve();
+      await flushAsyncWork();
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      deferredDNS.rejectForCleanup();
+    }
+  });
+});

--- a/test/unit/enhanced-secure-agent.test.ts
+++ b/test/unit/enhanced-secure-agent.test.ts
@@ -9,8 +9,9 @@ import http from 'http';
 import dns from 'dns';
 import net from 'net';
 import { 
-	  createEnhancedSecureHttpAgent,
-	  createEnhancedSecureHttpsAgent,
+	  __testDNSLookupLimiter,
+		  createEnhancedSecureHttpAgent,
+		  createEnhancedSecureHttpsAgent,
   getDNSCacheStats,
   invalidateDNSCache,
   validateRequestSecurity
@@ -79,6 +80,56 @@ function mockDNSLookup(hostname: string, addresses: dns.LookupAddress[]) {
     } catch (error) {
       console.warn('Failed to restore DNS lookup:', error);
     }
+  };
+}
+
+type DeferredDNSCallback = (
+  error: NodeJS.ErrnoException | null,
+  addresses: dns.LookupAddress[]
+) => void;
+
+function mockDeferredDNSLookups() {
+  const originalLookup = dns.lookup;
+  const startedHostnames: string[] = [];
+  const callbacks: Array<DeferredDNSCallback | undefined> = [];
+
+  (dns.lookup as any) = vi.fn((
+    hostname: string,
+    _options: unknown,
+    callback: DeferredDNSCallback
+  ) => {
+    startedHostnames.push(hostname);
+    callbacks.push(callback);
+  });
+
+  return {
+    startedHostnames,
+    get callbackCount() {
+      return callbacks.length;
+    },
+    resolve(index: number, addresses: dns.LookupAddress[] = [{ address: '8.8.8.8', family: 4 }]) {
+      const callback = callbacks[index];
+      if (!callback) {
+        throw new Error(`DNS callback ${index} is unavailable`);
+      }
+      callbacks[index] = undefined;
+      callback(null, addresses);
+    },
+    rejectAll() {
+      for (let index = 0; index < callbacks.length; index += 1) {
+        const callback = callbacks[index];
+        if (!callback) {
+          continue;
+        }
+        callbacks[index] = undefined;
+        const error = new Error('test cleanup') as NodeJS.ErrnoException;
+        error.code = 'ENOTFOUND';
+        callback(error, []);
+      }
+    },
+    restore() {
+      dns.lookup = originalLookup;
+    },
   };
 }
 
@@ -525,6 +576,257 @@ describe('Enhanced Secure Agent', () => {
       
       const stats = getDNSCacheStats();
       expect(stats.size).toBeLessThanOrEqual(stats.maxSize);
+    });
+  });
+
+  describe('DNS admission control', () => {
+    it('bounds native DNS lookups and starts queued lookups in FIFO order', async () => {
+      const deferredDNS = mockDeferredDNSLookups();
+      const controllers = Array.from({ length: 10 }, () => new AbortController());
+      cleanupFunctions.push(() => {
+        controllers.forEach(controller => controller.abort());
+        deferredDNS.rejectAll();
+        deferredDNS.restore();
+      });
+      mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+      const requests = Array.from({ length: 10 }, (_, index) =>
+        validateRequestSecurity(
+          `https://dns-limit-${index}.example/test`,
+          controllers[index].signal
+        )
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(deferredDNS.startedHostnames).toHaveLength(8);
+      expect(deferredDNS.startedHostnames).toEqual(
+        Array.from({ length: 8 }, (_, index) => `dns-limit-${index}.example`)
+      );
+
+      for (let index = 0; index < requests.length; index += 1) {
+        await vi.waitFor(() => expect(deferredDNS.callbackCount).toBeGreaterThan(index));
+        deferredDNS.resolve(index, [{ address: `8.8.8.${index + 1}`, family: 4 }]);
+      }
+
+      const results = await Promise.all(requests);
+      expect(results.every(result => result.allowed)).toBe(true);
+      expect(deferredDNS.startedHostnames).toEqual(
+        Array.from({ length: 10 }, (_, index) => `dns-limit-${index}.example`)
+      );
+
+      deferredDNS.restore();
+    });
+
+    it('does not release an active permit until the uncancellable native lookup settles', async () => {
+      const deferredDNS = mockDeferredDNSLookups();
+      const activeLimit = __testDNSLookupLimiter!.getStats().activeLimit;
+      const controllers = Array.from({ length: activeLimit + 1 }, () => new AbortController());
+      cleanupFunctions.push(() => {
+        controllers.forEach(controller => controller.abort());
+        deferredDNS.rejectAll();
+        deferredDNS.restore();
+      });
+      mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+      const firstRequest = validateRequestSecurity(
+        'https://dns-active-abort-0.example/test',
+        controllers[0].signal
+      );
+      void firstRequest.catch(() => undefined);
+      const otherActiveRequests = Array.from({ length: activeLimit - 1 }, (_, offset) => {
+        const index = offset + 1;
+        return validateRequestSecurity(
+          `https://dns-active-abort-${index}.example/test`,
+          controllers[index].signal
+        );
+      });
+      otherActiveRequests.forEach(request => void request.catch(() => undefined));
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(deferredDNS.startedHostnames).toHaveLength(activeLimit);
+
+      const queuedRequest = validateRequestSecurity(
+        `https://dns-active-abort-${activeLimit}.example/test`,
+        controllers[activeLimit].signal
+      );
+      void queuedRequest.catch(() => undefined);
+      await Promise.resolve();
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({
+        active: activeLimit,
+        queued: 1,
+      });
+
+      const abortReason = new Error('active DNS caller aborted');
+      const rejected = expect(firstRequest).rejects.toBe(abortReason);
+      controllers[0].abort(abortReason);
+      await rejected;
+      expect(deferredDNS.startedHostnames).toHaveLength(activeLimit);
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({
+        active: activeLimit,
+        queued: 1,
+      });
+
+      deferredDNS.resolve(0);
+      await vi.waitFor(() =>
+        expect(deferredDNS.startedHostnames).toHaveLength(activeLimit + 1)
+      );
+      expect(deferredDNS.startedHostnames.at(-1)).toBe(
+        `dns-active-abort-${activeLimit}.example`
+      );
+
+      for (let index = 1; index <= activeLimit; index += 1) {
+        deferredDNS.resolve(index);
+      }
+      const results = await Promise.all([...otherActiveRequests, queuedRequest]);
+      expect(results.every(result => result.allowed)).toBe(true);
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 });
+
+      deferredDNS.restore();
+    });
+
+    it('removes an aborted queued lookup without disturbing FIFO order', async () => {
+      const deferredDNS = mockDeferredDNSLookups();
+      const activeLimit = __testDNSLookupLimiter!.getStats().activeLimit;
+      const controllers = Array.from({ length: activeLimit + 2 }, () => new AbortController());
+      cleanupFunctions.push(() => {
+        controllers.forEach(controller => controller.abort());
+        deferredDNS.rejectAll();
+        deferredDNS.restore();
+      });
+      mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+      const activeRequests = Array.from({ length: activeLimit }, (_, index) =>
+        validateRequestSecurity(
+          `https://dns-queued-abort-${index}.example/test`,
+          controllers[index].signal
+        )
+      );
+      activeRequests.forEach(request => void request.catch(() => undefined));
+      const abortedQueuedRequest = validateRequestSecurity(
+        `https://dns-queued-abort-${activeLimit}.example/test`,
+        controllers[activeLimit].signal
+      );
+      void abortedQueuedRequest.catch(() => undefined);
+      const nextQueuedRequest = validateRequestSecurity(
+        `https://dns-queued-abort-${activeLimit + 1}.example/test`,
+        controllers[activeLimit + 1].signal
+      );
+      void nextQueuedRequest.catch(() => undefined);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({
+        active: activeLimit,
+        queued: 2,
+      });
+
+      const abortReason = new Error('queued DNS caller aborted');
+      const rejected = expect(abortedQueuedRequest).rejects.toBe(abortReason);
+      controllers[activeLimit].abort(abortReason);
+      await rejected;
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({
+        active: activeLimit,
+        queued: 1,
+      });
+
+      deferredDNS.resolve(0);
+      await vi.waitFor(() =>
+        expect(deferredDNS.startedHostnames).toHaveLength(activeLimit + 1)
+      );
+      expect(deferredDNS.startedHostnames.at(-1)).toBe(
+        `dns-queued-abort-${activeLimit + 1}.example`
+      );
+
+      for (let index = 1; index <= activeLimit; index += 1) {
+        deferredDNS.resolve(index);
+      }
+      const results = await Promise.all([...activeRequests, nextQueuedRequest]);
+      expect(results.every(result => result.allowed)).toBe(true);
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 });
+
+      deferredDNS.restore();
+    });
+
+    it('fails fast once the bounded DNS queue is full', async () => {
+      const deferredDNS = mockDeferredDNSLookups();
+      const limiterStats = __testDNSLookupLimiter!.getStats();
+      const requestCount = limiterStats.activeLimit + limiterStats.queuedLimit + 1;
+      const controllers = Array.from({ length: requestCount }, () => new AbortController());
+      cleanupFunctions.push(() => {
+        controllers.forEach(controller => controller.abort());
+        deferredDNS.rejectAll();
+        deferredDNS.restore();
+      });
+      mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+      const requests = Array.from({ length: requestCount }, (_, index) =>
+        validateRequestSecurity(
+          `https://dns-queue-full-${index}.example/test`,
+          controllers[index].signal
+        )
+      );
+      requests.forEach(request => void request.catch(() => undefined));
+
+      await Promise.resolve();
+      await Promise.resolve();
+      const overflowResult = await requests.at(-1)!;
+      expect(overflowResult.allowed).toBe(false);
+      expect(overflowResult.reason).toContain('DNS lookup queue limit reached');
+      expect(deferredDNS.startedHostnames).toHaveLength(limiterStats.activeLimit);
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({
+        active: limiterStats.activeLimit,
+        queued: limiterStats.queuedLimit,
+      });
+
+      controllers.slice(0, -1).forEach(controller => controller.abort());
+      await Promise.allSettled(requests.slice(0, -1));
+      expect(__testDNSLookupLimiter!.getStats()).toMatchObject({
+        active: limiterStats.activeLimit,
+        queued: 0,
+      });
+
+      deferredDNS.rejectAll();
+      await vi.waitFor(() =>
+        expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 })
+      );
+
+      deferredDNS.restore();
+    });
+
+    it('returns at the DNS deadline but retains the active permit until native settlement', async () => {
+      vi.useFakeTimers();
+      const deferredDNS = mockDeferredDNSLookups();
+      cleanupFunctions.push(() => {
+        deferredDNS.rejectAll();
+        deferredDNS.restore();
+      });
+      mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+      try {
+        const request = validateRequestSecurity('https://dns-deadline.example/test');
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+
+        await vi.advanceTimersByTimeAsync(__testDNSLookupLimiter!.getStats().timeoutMs);
+        const result = await request;
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('DNS lookup timed out after 30000ms');
+        expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 1, queued: 0 });
+
+        deferredDNS.resolve(0);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(__testDNSLookupLimiter!.getStats()).toMatchObject({ active: 0, queued: 0 });
+      } finally {
+        deferredDNS.rejectAll();
+        deferredDNS.restore();
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import { extractMetadata, validateMetadata, applyFallbacks, fetchImage } from '../../src/core/metadata-extractor';
-import { ExtractedMetadata } from '../../src/types';
+import { ErrorType, ExtractedMetadata } from '../../src/types';
 import { mockHtmlWithOg, mockHtmlMinimal, mockHtmlWithTwitter } from '../fixtures/mock-html';
 import axios from 'axios';
 import ogs from 'open-graph-scraper';
@@ -158,6 +158,39 @@ describe('Metadata Extractor', () => {
       await expect(extractMetadata(testUrl)).rejects.toThrow('Failed to fetch data');
     });
 
+    it('aborts a pending HTML response at the configured total deadline', async () => {
+      vi.useFakeTimers();
+      const testUrl = 'https://slow-html.example';
+      let requestSignal: AbortSignal | undefined;
+
+      mockedAxios.get.mockImplementationOnce((_url, config) => {
+        requestSignal = config?.signal;
+        return new Promise((_, reject) => {
+          requestSignal?.addEventListener(
+            'abort',
+            () => reject(requestSignal?.reason ?? new Error('aborted')),
+            { once: true }
+          );
+        });
+      });
+
+      const request = extractMetadata(testUrl, { timeout: 50 });
+      const rejected = expect(request).rejects.toMatchObject({
+        type: ErrorType.FETCH_ERROR,
+        message: expect.stringContaining('Network request deadline exceeded after 50ms'),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(requestSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(50);
+
+      await rejected;
+      expect(requestSignal?.aborted).toBe(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(0);
+      vi.useRealTimers();
+    });
+
     it('disables implicit environment proxies and configures protocol-specific secure agents', async () => {
       const testUrl = 'https://proxy-boundary.example/page';
 
@@ -270,6 +303,72 @@ describe('Metadata Extractor', () => {
   });
 
   describe('fetchImage', () => {
+    it('aborts a pending image request when the total request deadline expires', async () => {
+      vi.useFakeTimers();
+      const imageUrl = 'https://example.com/slow-image.jpg';
+      let requestSignal: AbortSignal | undefined;
+
+      mockedAxios.get.mockImplementationOnce((_url, config) => {
+        requestSignal = config?.signal;
+        return new Promise((_, reject) => {
+          requestSignal?.addEventListener(
+            'abort',
+            () => reject(requestSignal?.reason ?? new Error('aborted')),
+            { once: true }
+          );
+        });
+      });
+
+      const request = fetchImage(imageUrl, { timeout: 50 });
+      const rejected = expect(request).rejects.toMatchObject({
+        type: ErrorType.IMAGE_ERROR,
+        message: expect.stringContaining('Network request deadline exceeded after 50ms'),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockedAxios.get).toHaveBeenCalledOnce();
+      expect(requestSignal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(50);
+
+      await rejected;
+      expect(requestSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+      vi.useRealTimers();
+    });
+
+    it('composes caller abort with the image deadline and reports IMAGE_ERROR', async () => {
+      vi.useFakeTimers();
+      const imageUrl = 'https://example.com/caller-aborted.jpg';
+      const caller = new AbortController();
+      let requestSignal: AbortSignal | undefined;
+
+      mockedAxios.get.mockImplementationOnce((_url, config) => {
+        requestSignal = config?.signal;
+        return new Promise((_, reject) => {
+          requestSignal?.addEventListener(
+            'abort',
+            () => reject(requestSignal?.reason ?? new Error('aborted')),
+            { once: true }
+          );
+        });
+      });
+
+      const request = fetchImage(imageUrl, { timeout: 1000 }, caller.signal);
+      const rejected = expect(request).rejects.toMatchObject({
+        type: ErrorType.IMAGE_ERROR,
+        message: expect.stringContaining('Network request aborted by caller'),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      caller.abort();
+
+      await rejected;
+      expect(requestSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+      vi.useRealTimers();
+    });
+
     it('should fetch image successfully', async () => {
       const imageUrl = 'https://example.com/image.jpg';
       // Mock JPEG image data with proper magic bytes

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -341,6 +341,7 @@ describe('Metadata Extractor', () => {
       vi.useFakeTimers();
       const imageUrl = 'https://example.com/caller-aborted.jpg';
       const caller = new AbortController();
+      const callerReason = new Error('caller canceled image request');
       let requestSignal: AbortSignal | undefined;
 
       mockedAxios.get.mockImplementationOnce((_url, config) => {
@@ -357,11 +358,11 @@ describe('Metadata Extractor', () => {
       const request = fetchImage(imageUrl, { timeout: 1000 }, caller.signal);
       const rejected = expect(request).rejects.toMatchObject({
         type: ErrorType.IMAGE_ERROR,
-        message: expect.stringContaining('Network request aborted by caller'),
+        message: expect.stringContaining(callerReason.message),
       });
       await vi.advanceTimersByTimeAsync(0);
 
-      caller.abort();
+      caller.abort(callerReason);
 
       await rejected;
       expect(requestSignal?.aborted).toBe(true);

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -69,7 +69,7 @@ describe('Metadata Extractor', () => {
         publishedDate: undefined,
       });
       expect(mockedValidateRequestSecurity).toHaveBeenCalledWith(
-        testUrl,
+        new URL(testUrl).toString(),
         expect.any(AbortSignal)
       );
     });

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -5,6 +5,7 @@ import { mockHtmlWithOg, mockHtmlMinimal, mockHtmlWithTwitter } from '../fixture
 import axios from 'axios';
 import ogs from 'open-graph-scraper';
 import * as imageSecurity from '../../src/utils/image-security';
+import { validateRequestSecurity } from '../../src/utils/enhanced-secure-agent';
 
 vi.mock('axios');
 vi.mock('open-graph-scraper');
@@ -23,6 +24,7 @@ vi.mock('../../src/utils/enhanced-secure-agent', () => ({
 const mockedAxios = axios as vi.Mocked<typeof axios>;
 const mockedOgs = ogs as vi.MockedFunction<typeof ogs>;
 const mockedImageSecurity = imageSecurity as vi.Mocked<typeof imageSecurity>;
+const mockedValidateRequestSecurity = vi.mocked(validateRequestSecurity);
 
 describe('Metadata Extractor', () => {
   beforeEach(() => {
@@ -66,6 +68,10 @@ describe('Metadata Extractor', () => {
         author: undefined,
         publishedDate: undefined,
       });
+      expect(mockedValidateRequestSecurity).toHaveBeenCalledWith(
+        testUrl,
+        expect.any(AbortSignal)
+      );
     });
 
     it('should handle Twitter Card metadata', async () => {
@@ -372,6 +378,7 @@ describe('Metadata Extractor', () => {
 
     it('should fetch image successfully', async () => {
       const imageUrl = 'https://example.com/image.jpg';
+      const abortController = new AbortController();
       // Mock JPEG image data with proper magic bytes
       const mockImageData = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, ...Array(100).fill(0)]);
 
@@ -379,7 +386,9 @@ describe('Metadata Extractor', () => {
         data: mockImageData,
       });
 
-      const result = await fetchImage(imageUrl);
+      const result = await fetchImage(imageUrl, undefined, abortController.signal);
+
+      const securitySignal = mockedValidateRequestSecurity.mock.calls.at(-1)?.[1];
 
       expect(result).toEqual(mockImageData);
       expect(mockedAxios.get).toHaveBeenCalledWith(imageUrl, expect.objectContaining({
@@ -392,9 +401,16 @@ describe('Metadata Extractor', () => {
         maxContentLength: 15 * 1024 * 1024,
         maxBodyLength: 15 * 1024 * 1024,
         proxy: false,
+        signal: securitySignal,
         httpAgent: { kind: 'http' },
         httpsAgent: { kind: 'https' },
       }));
+      expect(mockedValidateRequestSecurity).toHaveBeenCalledWith(
+        imageUrl,
+        securitySignal
+      );
+      expect(securitySignal).toBeInstanceOf(AbortSignal);
+      expect(securitySignal).not.toBe(abortController.signal);
     });
 
     it('should throw error on fetch failure', async () => {

--- a/test/unit/network-request-control.test.ts
+++ b/test/unit/network-request-control.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  __testNetworkRequestLimiter,
+  NetworkRequestAbortedError,
+  NetworkRequestDeadlineError,
+  NetworkRequestQueueFullError,
+  runControlledNetworkRequest,
+} from '../../src/utils/network-request-control';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const limiter = __testNetworkRequestLimiter!;
+
+describe('network request control', () => {
+  afterEach(() => {
+    limiter.reset();
+    vi.useRealTimers();
+  });
+
+  it('aborts and rejects a pending transport at the total wall-clock deadline', async () => {
+    vi.useFakeTimers();
+    let requestSignal: AbortSignal | undefined;
+    const lateTransport = deferred();
+
+    const request = runControlledNetworkRequest(25, undefined, signal => {
+      requestSignal = signal;
+      // Deliberately ignore AbortSignal to verify the controller still settles
+      // the caller and returns the limiter permit.
+      return lateTransport.promise;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(limiter.getStats()).toMatchObject({ active: 1, queued: 0 });
+
+    const rejected = expect(request).rejects.toBeInstanceOf(NetworkRequestDeadlineError);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejected;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(limiter.getStats()).toMatchObject({ active: 0, queued: 0 });
+    expect(vi.getTimerCount()).toBe(0);
+
+    // A transport that rejects after the deadline must stay handled.
+    lateTransport.reject(new Error('late transport rejection'));
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('propagates caller abort and always removes the caller listener', async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const removeListener = vi.spyOn(caller.signal, 'removeEventListener');
+
+    const request = runControlledNetworkRequest(1000, caller.signal, signal =>
+      new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      })
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    const rejected = expect(request).rejects.toBeInstanceOf(NetworkRequestAbortedError);
+    caller.abort();
+
+    await rejected;
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(limiter.getStats()).toMatchObject({ active: 0, queued: 0 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cleans the deadline timer and caller listener after success', async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const removeListener = vi.spyOn(caller.signal, 'removeEventListener');
+
+    await expect(
+      runControlledNetworkRequest(1000, caller.signal, async () => 'ok')
+    ).resolves.toBe('ok');
+
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(limiter.getStats()).toMatchObject({ active: 0, queued: 0 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('releases permits on success and failure and starts queued work in FIFO order', async () => {
+    vi.useFakeTimers();
+    const activeWork = Array.from({ length: 50 }, () => deferred());
+    const startOrder: string[] = [];
+
+    const activeRequests = activeWork.map((work, index) =>
+      runControlledNetworkRequest(60_000, undefined, async () => {
+        startOrder.push(`active-${index}`);
+        await work.promise;
+      })
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    const queuedA = runControlledNetworkRequest(60_000, undefined, async () => {
+      startOrder.push('queued-a');
+      return 'a';
+    });
+    const queuedB = runControlledNetworkRequest(60_000, undefined, async () => {
+      startOrder.push('queued-b');
+      throw new Error('expected queued failure');
+    });
+    void queuedB.catch(() => undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(limiter.getStats()).toMatchObject({ active: 50, queued: 2 });
+
+    activeWork[0].resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(queuedA).resolves.toBe('a');
+    await expect(queuedB).rejects.toThrow('expected queued failure');
+    expect(startOrder.slice(-2)).toEqual(['queued-a', 'queued-b']);
+    expect(limiter.getStats()).toMatchObject({ active: 49, queued: 0 });
+
+    for (const work of activeWork.slice(1)) {
+      work.resolve();
+    }
+    await Promise.all(activeRequests);
+
+    expect(limiter.getStats()).toMatchObject({ active: 0, queued: 0 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('removes an aborted queued request without consuming a permit', async () => {
+    vi.useFakeTimers();
+    const activeWork = Array.from({ length: 50 }, () => deferred());
+    const activeRequests = activeWork.map(work =>
+      runControlledNetworkRequest(60_000, undefined, async () => work.promise)
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    const caller = new AbortController();
+    const queued = runControlledNetworkRequest(60_000, caller.signal, async () => 'never');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(limiter.getStats()).toMatchObject({ active: 50, queued: 1 });
+
+    const rejected = expect(queued).rejects.toBeInstanceOf(NetworkRequestAbortedError);
+    caller.abort();
+    await rejected;
+    expect(limiter.getStats()).toMatchObject({ active: 50, queued: 0 });
+
+    for (const work of activeWork) {
+      work.resolve();
+    }
+    await Promise.all(activeRequests);
+    expect(limiter.getStats()).toMatchObject({ active: 0, queued: 0 });
+  });
+
+  it('bounds the FIFO queue at 1000 requests and fails overflow immediately', async () => {
+    vi.useFakeTimers();
+    const activeWork = Array.from({ length: 50 }, () => deferred());
+    const activeRequests = activeWork.map(work =>
+      runControlledNetworkRequest(60_000, undefined, async () => work.promise)
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    const queuedRequests = Array.from({ length: 1000 }, () =>
+      runControlledNetworkRequest(60_000, undefined, async () => undefined)
+    );
+    for (const request of queuedRequests) {
+      void request.catch(() => undefined);
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(limiter.getStats()).toEqual({
+      active: 50,
+      queued: 1000,
+      activeLimit: 50,
+      queuedLimit: 1000,
+    });
+    await expect(
+      runControlledNetworkRequest(60_000, undefined, async () => undefined)
+    ).rejects.toBeInstanceOf(NetworkRequestQueueFullError);
+
+    limiter.reset();
+    await Promise.allSettled(queuedRequests);
+    for (const work of activeWork) {
+      work.resolve();
+    }
+    await Promise.all(activeRequests);
+    expect(limiter.getStats()).toMatchObject({ active: 0, queued: 0 });
+  });
+});

--- a/test/unit/network-request-control.test.ts
+++ b/test/unit/network-request-control.test.ts
@@ -52,6 +52,24 @@ describe('network request control', () => {
     await vi.advanceTimersByTimeAsync(0);
   });
 
+  it('preserves the deadline reason when a transport rejects with a generic cancel error', async () => {
+    vi.useFakeTimers();
+
+    const request = runControlledNetworkRequest(25, undefined, signal =>
+      new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('canceled')), { once: true });
+      })
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    const rejected = expect(request).rejects.toBeInstanceOf(NetworkRequestDeadlineError);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejected;
+    expect(limiter.getStats()).toMatchObject({ active: 0, queued: 0 });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('propagates caller abort and always removes the caller listener', async () => {
     vi.useFakeTimers();
     const caller = new AbortController();
@@ -60,7 +78,7 @@ describe('network request control', () => {
 
     const request = runControlledNetworkRequest(1000, caller.signal, signal =>
       new Promise((_, reject) => {
-        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        signal.addEventListener('abort', () => reject(new Error('canceled')), { once: true });
       })
     );
     await vi.advanceTimersByTimeAsync(0);

--- a/test/unit/network-request-control.test.ts
+++ b/test/unit/network-request-control.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   __testNetworkRequestLimiter,
-  NetworkRequestAbortedError,
   NetworkRequestDeadlineError,
   NetworkRequestQueueFullError,
   runControlledNetworkRequest,
@@ -56,6 +55,7 @@ describe('network request control', () => {
   it('propagates caller abort and always removes the caller listener', async () => {
     vi.useFakeTimers();
     const caller = new AbortController();
+    const callerReason = new Error('caller canceled network request');
     const removeListener = vi.spyOn(caller.signal, 'removeEventListener');
 
     const request = runControlledNetworkRequest(1000, caller.signal, signal =>
@@ -65,8 +65,8 @@ describe('network request control', () => {
     );
     await vi.advanceTimersByTimeAsync(0);
 
-    const rejected = expect(request).rejects.toBeInstanceOf(NetworkRequestAbortedError);
-    caller.abort();
+    const rejected = expect(request).rejects.toBe(callerReason);
+    caller.abort(callerReason);
 
     await rejected;
     expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
@@ -144,9 +144,9 @@ describe('network request control', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(limiter.getStats()).toMatchObject({ active: 50, queued: 1 });
 
-    const rejected = expect(queued).rejects.toBeInstanceOf(NetworkRequestAbortedError);
+    const rejected = queued.catch(error => error);
     caller.abort();
-    await rejected;
+    await expect(rejected).resolves.toBe(caller.signal.reason);
     expect(limiter.getStats()).toMatchObject({ active: 50, queued: 0 });
 
     for (const work of activeWork) {

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -241,6 +241,33 @@ describe('Validators', () => {
     test.each([1, 90, 100])('should accept integer quality %i', quality => {
       expect(sanitizeOptions({ quality }).quality).toBe(quality);
     });
+
+    test.each([
+      NaN,
+      Infinity,
+      -Infinity,
+      0,
+      -1,
+      1.5,
+      30_001,
+      '1000' as unknown as number,
+    ])('should reject invalid security timeout %s with VALIDATION_ERROR', timeout => {
+      try {
+        sanitizeOptions({ security: { timeout } });
+        throw new Error('Expected sanitizeOptions to reject the timeout');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PreviewGeneratorError);
+        expect((error as PreviewGeneratorError).type).toBe(ErrorType.VALIDATION_ERROR);
+        expect((error as PreviewGeneratorError).message).toContain('Security timeout');
+      }
+    });
+
+    test.each([1, 8000, 12000, 30_000])(
+      'should preserve valid security timeout %i',
+      timeout => {
+        expect(sanitizeOptions({ security: { timeout } }).security?.timeout).toBe(timeout);
+      }
+    );
   });
 
   describe('createTransparentCanvas', () => {


### PR DESCRIPTION
## Summary
- apply one wall-clock deadline across queue wait and Axios body transfer
- add a process-wide FIFO outbound request limiter with bounded queueing and abort-safe permit release
- validate public security timeout values before network I/O

## Verification
- pnpm run lint
- pnpm test (26 files, 500 tests)
- pnpm run build
- pnpm run verify:release -- --tag v0.2.6
- pnpm run verify:package
- git diff --check