### PR TITLE
fix(render): bound native image processing

### DIFF
--- a/src/core/image-generator.ts
+++ b/src/core/image-generator.ts
@@ -17,7 +17,7 @@ import { createCachedCanvas, createCachedSVG } from '../utils/sharp-cache';
 import { SYSTEM_FONT_STACK } from '../constants/fonts';
 import { fetchImage } from './metadata-extractor';
 import { createTransparentCanvas, validateColor } from '../utils/validators';
-import { withRenderSlot } from '../utils/render-limiter';
+import { withPreparedRenderSlot, withRenderSlot } from '../utils/render-limiter';
 
 /**
  * Default dimensions for social media preview images
@@ -44,9 +44,8 @@ export async function generateImage(
   const width = options.width || DEFAULT_DIMENSIONS.width;
   const height = options.height || DEFAULT_DIMENSIONS.height;
   const quality = options.quality || 90;
-  const imageBuffer = metadata.image ? await fetchImage(metadata.image) : undefined;
 
-  return withRenderSlot(async () => {
+  const renderPreparedImage = async (imageBuffer?: Buffer): Promise<Buffer> => {
     try {
       // Create base image or use existing image
       let baseImage: Sharp;
@@ -89,7 +88,17 @@ export async function generateImage(
       }
       throw new PreviewGeneratorError(ErrorType.IMAGE_ERROR, 'Failed to generate image', error);
     }
-  });
+  };
+
+  const imageUrl = metadata.image;
+  if (imageUrl) {
+    return withPreparedRenderSlot(
+      () => fetchImage(imageUrl),
+      renderPreparedImage
+    );
+  }
+
+  return withRenderSlot(() => renderPreparedImage());
 }
 
 /**

--- a/src/core/image-generator.ts
+++ b/src/core/image-generator.ts
@@ -17,6 +17,7 @@ import { createCachedCanvas, createCachedSVG } from '../utils/sharp-cache';
 import { SYSTEM_FONT_STACK } from '../constants/fonts';
 import { fetchImage } from './metadata-extractor';
 import { createTransparentCanvas, validateColor } from '../utils/validators';
+import { withRenderSlot } from '../utils/render-limiter';
 
 /**
  * Default dimensions for social media preview images
@@ -40,53 +41,55 @@ export async function generateImage(
   template: TemplateConfig,
   options: PreviewOptions = {}
 ): Promise<Buffer> {
-  try {
-    const width = options.width || DEFAULT_DIMENSIONS.width;
-    const height = options.height || DEFAULT_DIMENSIONS.height;
-    const quality = options.quality || 90;
+  return withRenderSlot(async () => {
+    try {
+      const width = options.width || DEFAULT_DIMENSIONS.width;
+      const height = options.height || DEFAULT_DIMENSIONS.height;
+      const quality = options.quality || 90;
 
-    // Create base image or use existing image
-    let baseImage: Sharp;
+      // Create base image or use existing image
+      let baseImage: Sharp;
 
-    if (metadata.image) {
-      // Use existing image as background
-      const imageBuffer = await fetchImage(metadata.image);
-      baseImage = await processBackgroundImage(imageBuffer, width, height, template);
-    } else {
-      // Create blank canvas with gradient background or transparent canvas based on template settings
-      if (template.imageProcessing?.requiresTransparentCanvas) {
-        baseImage = createTransparentCanvas(width, height);
+      if (metadata.image) {
+        // Use existing image as background
+        const imageBuffer = await fetchImage(metadata.image);
+        baseImage = await processBackgroundImage(imageBuffer, width, height, template);
       } else {
-        baseImage = await createBlankCanvas(width, height, options);
+        // Create blank canvas with gradient background or transparent canvas based on template settings
+        if (template.imageProcessing?.requiresTransparentCanvas) {
+          baseImage = createTransparentCanvas(width, height);
+        } else {
+          baseImage = await createBlankCanvas(width, height, options);
+        }
       }
+
+      // Generate text overlay SVG
+      const overlayBuffer = await generateTextOverlay(metadata, template, width, height, options);
+
+      // Composite text overlay on base image
+      const finalImage = await baseImage
+        .composite([
+          {
+            input: overlayBuffer,
+            top: 0,
+            left: 0,
+          },
+        ])
+        .jpeg({
+          quality,
+          progressive: true,
+          mozjpeg: true
+        })
+        .toBuffer();
+
+      return finalImage;
+    } catch (error) {
+      if (error instanceof PreviewGeneratorError) {
+        throw error;
+      }
+      throw new PreviewGeneratorError(ErrorType.IMAGE_ERROR, 'Failed to generate image', error);
     }
-
-    // Generate text overlay SVG
-    const overlayBuffer = await generateTextOverlay(metadata, template, width, height, options);
-
-    // Composite text overlay on base image
-    const finalImage = await baseImage
-      .composite([
-        {
-          input: overlayBuffer,
-          top: 0,
-          left: 0,
-        },
-      ])
-      .jpeg({
-        quality,
-        progressive: true,
-        mozjpeg: true
-      })
-      .toBuffer();
-
-    return finalImage;
-  } catch (error) {
-    if (error instanceof PreviewGeneratorError) {
-      throw error;
-    }
-    throw new PreviewGeneratorError(ErrorType.IMAGE_ERROR, 'Failed to generate image', error);
-  }
+  });
 }
 
 /**

--- a/src/core/image-generator.ts
+++ b/src/core/image-generator.ts
@@ -41,18 +41,18 @@ export async function generateImage(
   template: TemplateConfig,
   options: PreviewOptions = {}
 ): Promise<Buffer> {
+  const width = options.width || DEFAULT_DIMENSIONS.width;
+  const height = options.height || DEFAULT_DIMENSIONS.height;
+  const quality = options.quality || 90;
+  const imageBuffer = metadata.image ? await fetchImage(metadata.image) : undefined;
+
   return withRenderSlot(async () => {
     try {
-      const width = options.width || DEFAULT_DIMENSIONS.width;
-      const height = options.height || DEFAULT_DIMENSIONS.height;
-      const quality = options.quality || 90;
-
       // Create base image or use existing image
       let baseImage: Sharp;
 
-      if (metadata.image) {
+      if (imageBuffer) {
         // Use existing image as background
-        const imageBuffer = await fetchImage(metadata.image);
         baseImage = await processBackgroundImage(imageBuffer, width, height, template);
       } else {
         // Create blank canvas with gradient background or transparent canvas based on template settings

--- a/src/core/template-image-processing.ts
+++ b/src/core/template-image-processing.ts
@@ -12,18 +12,45 @@ export interface ProcessedTemplateImage {
   usedBackgroundImage: boolean;
 }
 
-export async function processImageForTemplate(
+export interface PreparedTemplateImage {
+  effectiveMetadata: ExtractedMetadata;
+  imageBuffer?: Buffer;
+}
+
+/** Fetch and validate optional background bytes before native render admission. */
+export async function prepareImageForTemplate(
   metadata: ExtractedMetadata,
+  template: TemplateConfig,
+  options: SanitizedOptions
+): Promise<PreparedTemplateImage> {
+  const effectiveMetadata = { ...metadata };
+
+  if (template.layout.imagePosition === 'none' || !metadata.image) {
+    return { effectiveMetadata };
+  }
+
+  try {
+    const imageBuffer = await fetchImage(metadata.image, options.security);
+    return { effectiveMetadata, imageBuffer };
+  } catch (fetchError) {
+    logImageFetchError(
+      metadata.image,
+      fetchError instanceof Error ? fetchError : new Error(String(fetchError))
+    );
+    return { effectiveMetadata: { ...metadata, image: undefined } };
+  }
+}
+
+export async function processImageForTemplate(
+  preparedImage: PreparedTemplateImage,
   template: TemplateConfig,
   width: number,
   height: number,
   options: SanitizedOptions
 ): Promise<ProcessedTemplateImage> {
-  const effectiveMetadata = { ...metadata };
+  const effectiveMetadata = { ...preparedImage.effectiveMetadata };
 
-  // Check if template wants no background image
-  if (template.layout.imagePosition === 'none') {
-    // Use transparent canvas if template requires it, otherwise use blank canvas
+  if (!preparedImage.imageBuffer) {
     if (template.imageProcessing?.requiresTransparentCanvas) {
       return {
         baseImage: createTransparentCanvas(width, height),
@@ -38,28 +65,8 @@ export async function processImageForTemplate(
     };
   }
 
-  // If no image available, handle based on template configuration
-  if (!metadata.image) {
-    // Use transparent canvas if template requires it for custom backgrounds
-    if (template.imageProcessing?.requiresTransparentCanvas) {
-      return {
-        baseImage: createTransparentCanvas(width, height),
-        effectiveMetadata,
-        usedBackgroundImage: false,
-      };
-    }
-    return {
-      baseImage: await createBlankCanvas(width, height, options),
-      effectiveMetadata,
-      usedBackgroundImage: false,
-    };
-  }
-
-  // Process background image with template-specific effects
   try {
-    const imageBuffer = await fetchImage(metadata.image, options.security);
-
-    const baseImage = await withSecureSharp(imageBuffer, async (secureImage) => {
+    const baseImage = await withSecureSharp(preparedImage.imageBuffer, async (secureImage) => {
       let processedImage = secureResize(secureImage, width, height, {
         fit: 'cover',
         position: 'center',
@@ -94,14 +101,13 @@ export async function processImageForTemplate(
     });
 
     return { baseImage, effectiveMetadata, usedBackgroundImage: true };
-  } catch (fetchError) {
-    // If image fetch fails, create appropriate canvas based on template configuration
+  } catch (processingError) {
     logImageFetchError(
-      metadata.image,
-      fetchError instanceof Error ? fetchError : new Error(String(fetchError))
+      effectiveMetadata.image ?? 'background image',
+      processingError instanceof Error ? processingError : new Error(String(processingError))
     );
 
-    const metadataWithoutFailedImage = { ...metadata, image: undefined };
+    const metadataWithoutFailedImage = { ...effectiveMetadata, image: undefined };
 
     // Use transparent canvas if template requires it for custom backgrounds
     if (template.imageProcessing?.requiresTransparentCanvas) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { generateDefaultOverlay } from './core/overlay-generator';
 import {
   prepareImageForTemplate,
   processImageForTemplate,
+  type PreparedTemplateImage,
   type ProcessedTemplateImage,
 } from './core/template-image-processing';
 import { getCachedPreview, setCachedPreview } from './utils/preview-cache';
@@ -34,7 +35,7 @@ import { createCachedSVG } from './utils/sharp-cache';
 import { startCacheCleanup, isCacheCleanupRunning } from './utils/cache';
 import { MAX_TEXT_LENGTH } from './constants/security';
 import { exceedsTextLength } from './utils/validators/text';
-import { withRenderSlot } from './utils/render-limiter';
+import { withPreparedRenderSlot, withRenderSlot } from './utils/render-limiter';
 import { isSharpProcessingTimeout } from './utils/sharp-timeout';
 
 // Initialize Sharp security settings (no side-effect timers at import time)
@@ -263,9 +264,10 @@ async function generateImageWithSanitizedOptions(
   const width = sanitizedOptions.width || DEFAULT_DIMENSIONS.width;
   const height = sanitizedOptions.height || DEFAULT_DIMENSIONS.height;
   const quality = sanitizedOptions.quality || 90;
-  const preparedImage = await prepareImageForTemplate(metadata, template, sanitizedOptions);
 
-  return withRenderSlot(async () => {
+  const renderPreparedImage = async (
+    preparedImage: PreparedTemplateImage
+  ): Promise<RenderedImage> => {
     try {
       validateDimensions(width, height);
 
@@ -326,7 +328,17 @@ async function generateImageWithSanitizedOptions(
         error
       );
     }
-  });
+  };
+
+  if (template.layout.imagePosition !== 'none' && metadata.image) {
+    return withPreparedRenderSlot(
+      () => prepareImageForTemplate(metadata, template, sanitizedOptions),
+      renderPreparedImage
+    );
+  }
+
+  const preparedImage = await prepareImageForTemplate(metadata, template, sanitizedOptions);
+  return withRenderSlot(() => renderPreparedImage(preparedImage));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
 import { initializeSharpSecurity } from './utils/image-security';
 import { generateDefaultOverlay } from './core/overlay-generator';
 import {
+  prepareImageForTemplate,
   processImageForTemplate,
   type ProcessedTemplateImage,
 } from './core/template-image-processing';
@@ -262,13 +263,14 @@ async function generateImageWithSanitizedOptions(
   const width = sanitizedOptions.width || DEFAULT_DIMENSIONS.width;
   const height = sanitizedOptions.height || DEFAULT_DIMENSIONS.height;
   const quality = sanitizedOptions.quality || 90;
+  const preparedImage = await prepareImageForTemplate(metadata, template, sanitizedOptions);
 
   return withRenderSlot(async () => {
     try {
       validateDimensions(width, height);
 
       let processedImage = await processImageForTemplate(
-        metadata,
+        preparedImage,
         template,
         width,
         height,
@@ -295,7 +297,9 @@ async function generateImageWithSanitizedOptions(
         // metadata minus the failed background image. Native Sharp timeouts are
         // never retried because doing so doubles work after resource exhaustion.
         processedImage = await processImageForTemplate(
-          { ...processedImage.effectiveMetadata, image: undefined },
+          {
+            effectiveMetadata: { ...processedImage.effectiveMetadata, image: undefined },
+          },
           template,
           width,
           height,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ import { createCachedSVG } from './utils/sharp-cache';
 import { startCacheCleanup, isCacheCleanupRunning } from './utils/cache';
 import { MAX_TEXT_LENGTH } from './constants/security';
 import { exceedsTextLength } from './utils/validators/text';
+import { withRenderSlot } from './utils/render-limiter';
+import { isSharpProcessingTimeout } from './utils/sharp-timeout';
 
 // Initialize Sharp security settings (no side-effect timers at import time)
 initializeSharpSecurity();
@@ -261,63 +263,66 @@ async function generateImageWithSanitizedOptions(
   const height = sanitizedOptions.height || DEFAULT_DIMENSIONS.height;
   const quality = sanitizedOptions.quality || 90;
 
-  try {
-    validateDimensions(width, height);
-
-    let processedImage = await processImageForTemplate(
-      metadata,
-      template,
-      width,
-      height,
-      sanitizedOptions
-    );
-    let overlayBuffer = await createOverlayBuffer(
-      processedImage.effectiveMetadata,
-      template,
-      width,
-      height,
-      sanitizedOptions
-    );
-
-    let finalImage: Buffer;
+  return withRenderSlot(async () => {
     try {
-      finalImage = await renderProcessedImage(processedImage, overlayBuffer, quality);
-    } catch (processingError) {
-      if (!processedImage.usedBackgroundImage) {
-        throw processingError;
-      }
+      validateDimensions(width, height);
 
-      // Sharp evaluates image pipelines lazily, so decoding/resizing can fail
-      // only while producing the final buffer. Retry once with the same
-      // metadata minus the failed background image.
-      processedImage = await processImageForTemplate(
-        { ...processedImage.effectiveMetadata, image: undefined },
+      let processedImage = await processImageForTemplate(
+        metadata,
         template,
         width,
         height,
         sanitizedOptions
       );
-      overlayBuffer = await createOverlayBuffer(
+      let overlayBuffer = await createOverlayBuffer(
         processedImage.effectiveMetadata,
         template,
         width,
         height,
         sanitizedOptions
       );
-      finalImage = await renderProcessedImage(processedImage, overlayBuffer, quality);
-    }
 
-    return {
-      buffer: finalImage,
-      effectiveMetadata: processedImage.effectiveMetadata,
-    };
-  } catch (error) {
-    throw new PreviewGeneratorError(
-      ErrorType.IMAGE_ERROR,
-      `Failed to generate image with template: ${error instanceof Error ? error.message : String(error)}`,
-      error
-    );
-  }
+      let finalImage: Buffer;
+      try {
+        finalImage = await renderProcessedImage(processedImage, overlayBuffer, quality);
+      } catch (processingError) {
+        if (!processedImage.usedBackgroundImage || isSharpProcessingTimeout(processingError)) {
+          throw processingError;
+        }
+
+        // Sharp evaluates image pipelines lazily, so decoding/resizing can fail
+        // only while producing the final buffer. Retry once with the same
+        // metadata minus the failed background image. Native Sharp timeouts are
+        // never retried because doing so doubles work after resource exhaustion.
+        processedImage = await processImageForTemplate(
+          { ...processedImage.effectiveMetadata, image: undefined },
+          template,
+          width,
+          height,
+          sanitizedOptions
+        );
+        overlayBuffer = await createOverlayBuffer(
+          processedImage.effectiveMetadata,
+          template,
+          width,
+          height,
+          sanitizedOptions
+        );
+        finalImage = await renderProcessedImage(processedImage, overlayBuffer, quality);
+      }
+
+      return {
+        buffer: finalImage,
+        effectiveMetadata: processedImage.effectiveMetadata,
+      };
+    } catch (error) {
+      throw new PreviewGeneratorError(
+        ErrorType.IMAGE_ERROR,
+        `Failed to generate image with template: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  });
 }
 
 /**

--- a/src/utils/image-security.ts
+++ b/src/utils/image-security.ts
@@ -28,6 +28,7 @@ import {
   SHARP_CACHE_CONFIG,
   SHARP_SECURITY_CONFIG,
 } from '../constants/security';
+import { applySharpProcessingTimeout } from './sharp-timeout';
 
 // Import centralized constants from security module
 // All security limits are now defined in src/constants/security.ts
@@ -433,7 +434,7 @@ export function sanitizeSvgContent(svgContent: string): string {
  */
 export function createSecureSharpInstance(imageBuffer: Buffer): Sharp {
   // This will be called after validateImageBuffer, so we know it's safe
-  return sharp(imageBuffer, SHARP_SECURITY_CONFIG);
+  return applySharpProcessingTimeout(sharp(imageBuffer, SHARP_SECURITY_CONFIG));
 }
 
 /**
@@ -444,35 +445,8 @@ export async function withSecureSharp<T>(
   imageBuffer: Buffer,
   operation: (sharp: Sharp) => Promise<T>
 ): Promise<T> {
-  const sharpInstance = sharp(imageBuffer, SHARP_SECURITY_CONFIG);
+  const sharpInstance = applySharpProcessingTimeout(sharp(imageBuffer, SHARP_SECURITY_CONFIG));
   return await operation(sharpInstance);
-}
-
-/**
- * Process image with timeout protection to prevent DoS attacks
- */
-export async function processImageWithTimeout<T>(
-  operation: () => Promise<T>,
-  timeoutMs: number = PROCESSING_TIMEOUT
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new PreviewGeneratorError(
-        ErrorType.IMAGE_ERROR,
-        `Image processing timed out after ${timeoutMs}ms. This may indicate a malicious image designed to cause resource exhaustion.`
-      ));
-    }, timeoutMs);
-
-    operation()
-      .then(result => {
-        clearTimeout(timer);
-        resolve(result);
-      })
-      .catch(error => {
-        clearTimeout(timer);
-        reject(error);
-      });
-  });
 }
 
 /**
@@ -511,7 +485,7 @@ export function secureResize(
  * Create a Sharp instance with metadata removal for privacy and security
  */
 export function createSecureSharpWithCleanMetadata(imageBuffer: Buffer): Sharp {
-  return sharp(imageBuffer, SHARP_SECURITY_CONFIG)
+  return applySharpProcessingTimeout(sharp(imageBuffer, SHARP_SECURITY_CONFIG))
     // Remove EXIF and other metadata by default - use empty metadata
     .withMetadata({});
 }
@@ -524,7 +498,9 @@ export async function withSecureSharpCleanMetadata<T>(
   imageBuffer: Buffer,
   operation: (sharp: Sharp) => Promise<T>
 ): Promise<T> {
-  const sharpInstance = sharp(imageBuffer, SHARP_SECURITY_CONFIG).withMetadata({});
+  const sharpInstance = applySharpProcessingTimeout(
+    sharp(imageBuffer, SHARP_SECURITY_CONFIG)
+  ).withMetadata({});
   return await operation(sharpInstance);
 }
 

--- a/src/utils/render-limiter.ts
+++ b/src/utils/render-limiter.ts
@@ -31,10 +31,10 @@ function createRelease(): ReleaseRenderSlot {
 }
 
 /** Acquire one process-wide render slot, preserving FIFO queue order. */
-export function acquireRenderSlot(): Promise<ReleaseRenderSlot> {
+export async function acquireRenderSlot(): Promise<ReleaseRenderSlot> {
   if (activeRenders < MAX_ACTIVE_RENDERS) {
     activeRenders++;
-    return Promise.resolve(createRelease());
+    return createRelease();
   }
 
   if (renderQueue.length >= MAX_QUEUED_RENDERS) {

--- a/src/utils/render-limiter.ts
+++ b/src/utils/render-limiter.ts
@@ -1,0 +1,81 @@
+import { ErrorType, PreviewGeneratorError } from '../types';
+
+const MAX_ACTIVE_RENDERS = 4;
+const MAX_QUEUED_RENDERS = 32;
+
+type ReleaseRenderSlot = () => void;
+
+interface QueuedRender {
+  resolve: (release: ReleaseRenderSlot) => void;
+}
+
+const renderQueue: QueuedRender[] = [];
+let activeRenders = 0;
+
+function createRelease(): ReleaseRenderSlot {
+  let released = false;
+
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    activeRenders--;
+
+    const next = renderQueue.shift();
+    if (next) {
+      activeRenders++;
+      next.resolve(createRelease());
+    }
+  };
+}
+
+/** Acquire one process-wide render slot, preserving FIFO queue order. */
+export function acquireRenderSlot(): Promise<ReleaseRenderSlot> {
+  if (activeRenders < MAX_ACTIVE_RENDERS) {
+    activeRenders++;
+    return Promise.resolve(createRelease());
+  }
+
+  if (renderQueue.length >= MAX_QUEUED_RENDERS) {
+    throw new PreviewGeneratorError(
+      ErrorType.IMAGE_ERROR,
+      `Render queue is full (${MAX_ACTIVE_RENDERS} active, ${MAX_QUEUED_RENDERS} queued)`
+    );
+  }
+
+  return new Promise<ReleaseRenderSlot>((resolve) => {
+    renderQueue.push({ resolve });
+  });
+}
+
+/** Hold one render slot until the complete native image pipeline settles. */
+export async function withRenderSlot<T>(operation: () => Promise<T>): Promise<T> {
+  const release = await acquireRenderSlot();
+
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+/** Internal diagnostics used by deterministic limiter tests. */
+export function getRenderLimiterStats() {
+  return {
+    active: activeRenders,
+    queued: renderQueue.length,
+    maxActive: MAX_ACTIVE_RENDERS,
+    maxQueued: MAX_QUEUED_RENDERS,
+  } as const;
+}
+
+/** Test-only reset. Refuse to orphan active or queued work. */
+export function resetRenderLimiterForTests(): void {
+  if (activeRenders !== 0 || renderQueue.length !== 0) {
+    throw new Error('Cannot reset render limiter while work is active or queued');
+  }
+
+  activeRenders = 0;
+  renderQueue.length = 0;
+}

--- a/src/utils/render-limiter.ts
+++ b/src/utils/render-limiter.ts
@@ -2,6 +2,8 @@ import { ErrorType, PreviewGeneratorError } from '../types';
 
 const MAX_ACTIVE_RENDERS = 4;
 const MAX_QUEUED_RENDERS = 32;
+const MAX_ACTIVE_IMAGE_PREPARATIONS = 4;
+const MAX_QUEUED_IMAGE_PREPARATIONS = 32;
 
 type ReleaseRenderSlot = () => void;
 
@@ -11,6 +13,8 @@ interface QueuedRender {
 
 const renderQueue: QueuedRender[] = [];
 let activeRenders = 0;
+const imagePreparationQueue: QueuedRender[] = [];
+let activeImagePreparations = 0;
 
 function createRelease(): ReleaseRenderSlot {
   let released = false;
@@ -26,6 +30,24 @@ function createRelease(): ReleaseRenderSlot {
     if (next) {
       activeRenders++;
       next.resolve(createRelease());
+    }
+  };
+}
+
+function createImagePreparationRelease(): ReleaseRenderSlot {
+  let released = false;
+
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    activeImagePreparations--;
+
+    const next = imagePreparationQueue.shift();
+    if (next) {
+      activeImagePreparations++;
+      next.resolve(createImagePreparationRelease());
     }
   };
 }
@@ -49,6 +71,25 @@ export async function acquireRenderSlot(): Promise<ReleaseRenderSlot> {
   });
 }
 
+/** Bound background fetch/validation and the prepared-buffer handoff to rendering. */
+export async function acquireImagePreparationSlot(): Promise<ReleaseRenderSlot> {
+  if (activeImagePreparations < MAX_ACTIVE_IMAGE_PREPARATIONS) {
+    activeImagePreparations++;
+    return createImagePreparationRelease();
+  }
+
+  if (imagePreparationQueue.length >= MAX_QUEUED_IMAGE_PREPARATIONS) {
+    throw new PreviewGeneratorError(
+      ErrorType.IMAGE_ERROR,
+      `Image preparation queue is full (${MAX_ACTIVE_IMAGE_PREPARATIONS} active, ${MAX_QUEUED_IMAGE_PREPARATIONS} queued)`
+    );
+  }
+
+  return new Promise<ReleaseRenderSlot>(resolve => {
+    imagePreparationQueue.push({ resolve });
+  });
+}
+
 /** Hold one render slot until the complete native image pipeline settles. */
 export async function withRenderSlot<T>(operation: () => Promise<T>): Promise<T> {
   const release = await acquireRenderSlot();
@@ -60,6 +101,29 @@ export async function withRenderSlot<T>(operation: () => Promise<T>): Promise<T>
   }
 }
 
+/**
+ * Prepare background bytes under a separate bound, then atomically hand them
+ * to a native render slot. Queued preparation entries retain no image Buffer.
+ */
+export async function withPreparedRenderSlot<Prepared, Result>(
+  prepare: () => Promise<Prepared>,
+  render: (prepared: Prepared) => Promise<Result>
+): Promise<Result> {
+  const releasePreparation = await acquireImagePreparationSlot();
+  let releaseRender: ReleaseRenderSlot | undefined;
+
+  try {
+    const prepared = await prepare();
+    releaseRender = await acquireRenderSlot();
+    releasePreparation();
+
+    return await render(prepared);
+  } finally {
+    releasePreparation();
+    releaseRender?.();
+  }
+}
+
 /** Internal diagnostics used by deterministic limiter tests. */
 export function getRenderLimiterStats() {
   return {
@@ -67,15 +131,26 @@ export function getRenderLimiterStats() {
     queued: renderQueue.length,
     maxActive: MAX_ACTIVE_RENDERS,
     maxQueued: MAX_QUEUED_RENDERS,
+    preparing: activeImagePreparations,
+    preparationQueued: imagePreparationQueue.length,
+    maxPreparing: MAX_ACTIVE_IMAGE_PREPARATIONS,
+    maxPreparationQueued: MAX_QUEUED_IMAGE_PREPARATIONS,
   } as const;
 }
 
 /** Test-only reset. Refuse to orphan active or queued work. */
 export function resetRenderLimiterForTests(): void {
-  if (activeRenders !== 0 || renderQueue.length !== 0) {
+  if (
+    activeRenders !== 0 ||
+    renderQueue.length !== 0 ||
+    activeImagePreparations !== 0 ||
+    imagePreparationQueue.length !== 0
+  ) {
     throw new Error('Cannot reset render limiter while work is active or queued');
   }
 
   activeRenders = 0;
   renderQueue.length = 0;
+  activeImagePreparations = 0;
+  imagePreparationQueue.length = 0;
 }

--- a/src/utils/sharp-cache.ts
+++ b/src/utils/sharp-cache.ts
@@ -17,6 +17,7 @@ import sharp, { type Metadata, type Sharp } from 'sharp';
 import crypto from 'crypto';
 import { SHARP_SECURITY_CONFIG } from '../constants/security';
 import { logger } from './logger';
+import { applySharpProcessingTimeout } from './sharp-timeout';
 
 // Generated SVGs declare their dimensions in CSS pixels. Sharp's default SVG
 // density preserves those dimensions, while the higher density used to inspect
@@ -246,7 +247,9 @@ class CanvasCache extends SharpLRUCache<string> {
     const cachedSvg = this.get(key);
     
     // Create fresh Sharp instance from cached SVG content
-    return cachedSvg ? sharp(Buffer.from(cachedSvg), GENERATED_SVG_SHARP_CONFIG) : undefined;
+    return cachedSvg
+      ? applySharpProcessingTimeout(sharp(Buffer.from(cachedSvg), GENERATED_SVG_SHARP_CONFIG))
+      : undefined;
   }
 
   cacheCanvas(width: number, height: number, options: CanvasOptions, svgContent: string): void {
@@ -290,7 +293,7 @@ export async function createCachedSVG(svgContent: string): Promise<Sharp> {
   }
 
   // Create Sharp instance from cached buffer
-  return sharp(buffer, GENERATED_SVG_SHARP_CONFIG);
+  return applySharpProcessingTimeout(sharp(buffer, GENERATED_SVG_SHARP_CONFIG));
 }
 
 /**
@@ -327,7 +330,9 @@ export async function createCachedCanvas(
     // Cache miss - create canvas and cache the SVG content
     const svgContent = createCanvasSVG(width, height, options);
     canvasCache.cacheCanvas(width, height, options, svgContent);
-    canvas = sharp(Buffer.from(svgContent), GENERATED_SVG_SHARP_CONFIG);
+    canvas = applySharpProcessingTimeout(
+      sharp(Buffer.from(svgContent), GENERATED_SVG_SHARP_CONFIG)
+    );
     logger?.debug?.('Canvas cache miss - cached new canvas SVG');
   } else {
     logger?.debug?.('Canvas cache hit');

--- a/src/utils/sharp-timeout.ts
+++ b/src/utils/sharp-timeout.ts
@@ -1,0 +1,47 @@
+import type { Sharp } from 'sharp';
+import { PROCESSING_TIMEOUT } from '../constants/security';
+
+const SHARP_PROCESSING_TIMEOUT_SECONDS = Math.ceil(PROCESSING_TIMEOUT / 1000);
+
+/**
+ * Attach Sharp's native libvips timeout to an output-capable pipeline.
+ *
+ * Unlike a Promise race, this stops the underlying native work rather than
+ * merely releasing the JavaScript caller while libvips keeps processing.
+ */
+export function applySharpProcessingTimeout(sharpInstance: Sharp): Sharp {
+  return sharpInstance.timeout({ seconds: SHARP_PROCESSING_TIMEOUT_SECONDS });
+}
+
+/**
+ * Detect the timeout error emitted by Sharp/libvips, including errors wrapped
+ * by this package's PreviewGeneratorError details/cause chains.
+ */
+export function isSharpProcessingTimeout(error: unknown): boolean {
+  const pending: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (pending.length > 0) {
+    const current = pending.shift();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    if (current instanceof Error && /(?:^|\s)timeout:\s*\d+% complete\b/i.test(current.message)) {
+      return true;
+    }
+
+    if (typeof current === 'object') {
+      const record = current as { cause?: unknown; details?: unknown };
+      if (record.cause !== undefined) {
+        pending.push(record.cause);
+      }
+      if (record.details !== undefined) {
+        pending.push(record.details);
+      }
+    }
+  }
+
+  return false;
+}

--- a/src/utils/validators/canvas.ts
+++ b/src/utils/validators/canvas.ts
@@ -1,18 +1,20 @@
 import sharp from 'sharp';
 import { SHARP_SECURITY_CONFIG } from '../../constants/security';
+import { applySharpProcessingTimeout } from '../sharp-timeout';
 
 /**
  * Creates a transparent canvas for templates that provide their own background.
  */
 export function createTransparentCanvas(width: number, height: number) {
-  return sharp({
-    create: {
-      width,
-      height,
-      channels: 4,
-      background: { r: 0, g: 0, b: 0, alpha: 0 }, // Transparent
-    },
-    ...SHARP_SECURITY_CONFIG,
-  });
+  return applySharpProcessingTimeout(
+    sharp({
+      create: {
+        width,
+        height,
+        channels: 4,
+        background: { r: 0, g: 0, b: 0, alpha: 0 }, // Transparent
+      },
+      ...SHARP_SECURITY_CONFIG,
+    })
+  );
 }
-

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -45,6 +45,7 @@ describe('End-to-End Integration Tests', () => {
 
     // Setup default mocks
     const mockSharpInstance = {
+      timeout: vi.fn().mockReturnThis(),
       resize: vi.fn().mockReturnThis(),
       blur: vi.fn().mockReturnThis(),
       modulate: vi.fn().mockReturnThis(),
@@ -397,6 +398,44 @@ describe('End-to-End Integration Tests', () => {
           expect.any(Object)
         );
         expect(result.metadata.image).toBeUndefined();
+      } finally {
+        templates.modern = originalTemplate;
+      }
+    });
+
+    it('does not retry a blank canvas after a native Sharp timeout', async () => {
+      const originalTemplate = templates.modern;
+      const overlayGenerator = vi.fn(
+        () => '<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" />'
+      );
+      templates.modern = { ...originalTemplate, overlayGenerator };
+      const pngImageBuffer = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+        'base64'
+      );
+      mockedAxios.get.mockResolvedValueOnce({
+        data: pngImageBuffer,
+        headers: { 'content-type': 'image/png' },
+      });
+      const sharpInstance = mockedSharp();
+      sharpInstance.toBuffer
+        .mockResolvedValueOnce(Buffer.from('rasterized-overlay'))
+        .mockRejectedValueOnce(new Error('timeout: 12% complete'))
+        .mockResolvedValue(Buffer.from('unexpected-retry'));
+
+      try {
+        await expect(
+          generatePreviewFromMetadataWithDetails({
+            title: 'Post With Slow Cover',
+            url: 'https://blog.example.com/posts/slow-cover',
+            image: 'https://cdn.example.com/covers/slow-cover.png',
+          })
+        ).rejects.toMatchObject({
+          type: ErrorType.IMAGE_ERROR,
+          message: expect.stringContaining('timeout: 12% complete'),
+        });
+        expect(overlayGenerator).toHaveBeenCalledTimes(1);
+        expect(sharpInstance.toBuffer).toHaveBeenCalledTimes(2);
       } finally {
         templates.modern = originalTemplate;
       }
@@ -776,6 +815,7 @@ describe('End-to-End Integration Tests', () => {
 
       // Mock sharp to fail
       const mockSharpInstance = {
+        timeout: vi.fn().mockReturnThis(),
         resize: vi.fn().mockReturnThis(),
         blur: vi.fn().mockReturnThis(),
         modulate: vi.fn().mockReturnThis(),

--- a/test/performance/cache-performance.test.ts
+++ b/test/performance/cache-performance.test.ts
@@ -35,6 +35,7 @@ describe('Sharp Caching Performance Tests', () => {
     
     // Setup default mocks
     const mockSharpInstance = {
+      timeout: vi.fn().mockReturnThis(),
       resize: vi.fn().mockReturnThis(),
       blur: vi.fn().mockReturnThis(),
       modulate: vi.fn().mockReturnThis(),

--- a/test/unit/image-generator.test.ts
+++ b/test/unit/image-generator.test.ts
@@ -13,6 +13,7 @@ describe('Image Generator', () => {
     
     // Setup default sharp mock chain
     const mockSharpInstance = {
+      timeout: vi.fn().mockReturnThis(),
       resize: vi.fn().mockReturnThis(),
       blur: vi.fn().mockReturnThis(),
       modulate: vi.fn().mockReturnThis(),
@@ -44,6 +45,7 @@ describe('Image Generator', () => {
       };
 
       const mockSharpInstance = {
+        timeout: vi.fn().mockReturnThis(),
         composite: vi.fn().mockReturnThis(),
         jpeg: vi.fn().mockReturnThis(),
         toBuffer: vi.fn().mockResolvedValue(Buffer.from('fallback-image')),
@@ -79,6 +81,7 @@ describe('Image Generator', () => {
       const options: PreviewOptions = {};
 
       const mockSharpInstance = {
+        timeout: vi.fn().mockReturnThis(),
         composite: vi.fn().mockReturnThis(),
         jpeg: vi.fn().mockReturnThis(),
         toBuffer: vi.fn().mockResolvedValue(Buffer.from('fallback-image')),
@@ -96,6 +99,7 @@ describe('Image Generator', () => {
   describe('error handling', () => {
     it('should handle sharp errors gracefully', async () => {
       const mockSharpInstance = {
+        timeout: vi.fn().mockReturnThis(),
         composite: vi.fn().mockReturnThis(),
         jpeg: vi.fn().mockReturnThis(),
         toBuffer: vi.fn().mockRejectedValue(new Error('Sharp processing error')),

--- a/test/unit/render-entrypoints.test.ts
+++ b/test/unit/render-entrypoints.test.ts
@@ -2,6 +2,15 @@ import { vi } from 'vitest';
 
 const renderMocks = vi.hoisted(() => {
   const withRenderSlot = vi.fn(async <T>(operation: () => Promise<T>): Promise<T> => operation());
+  const withPreparedRenderSlot = vi.fn(
+    async <Prepared, Result>(
+      prepare: () => Promise<Prepared>,
+      render: (prepared: Prepared) => Promise<Result>
+    ): Promise<Result> => {
+      const prepared = await prepare();
+      return withRenderSlot(() => render(prepared));
+    }
+  );
   const extractMetadata = vi.fn();
   const validateMetadata = vi.fn(() => true);
   const fetchImage = vi.fn().mockResolvedValue(Buffer.from('image'));
@@ -24,11 +33,19 @@ const renderMocks = vi.hoisted(() => {
     cache: vi.fn(),
   });
 
-  return { withRenderSlot, extractMetadata, validateMetadata, fetchImage, sharp };
+  return {
+    withRenderSlot,
+    withPreparedRenderSlot,
+    extractMetadata,
+    validateMetadata,
+    fetchImage,
+    sharp,
+  };
 });
 
 vi.mock('../../src/utils/render-limiter', () => ({
   withRenderSlot: renderMocks.withRenderSlot,
+  withPreparedRenderSlot: renderMocks.withPreparedRenderSlot,
 }));
 vi.mock('sharp', () => ({ default: renderMocks.sharp }));
 vi.mock('../../src/core/metadata-extractor', () => ({
@@ -81,6 +98,15 @@ describe('render limiter entrypoints', () => {
     vi.clearAllMocks();
     renderMocks.withRenderSlot.mockImplementation(async <T>(operation: () => Promise<T>) =>
       operation()
+    );
+    renderMocks.withPreparedRenderSlot.mockImplementation(
+      async <Prepared, Result>(
+        prepare: () => Promise<Prepared>,
+        render: (prepared: Prepared) => Promise<Result>
+      ) => {
+        const prepared = await prepare();
+        return renderMocks.withRenderSlot(() => render(prepared));
+      }
     );
     renderMocks.extractMetadata.mockResolvedValue({ ...metadata });
     renderMocks.validateMetadata.mockReturnValue(true);
@@ -150,6 +176,7 @@ describe('render limiter entrypoints', () => {
     await Promise.resolve();
 
     expect(renderMocks.fetchImage).toHaveBeenCalledOnce();
+    expect(renderMocks.withPreparedRenderSlot).toHaveBeenCalledOnce();
     expect(renderMocks.withRenderSlot).not.toHaveBeenCalled();
 
     pendingImage.resolve(Buffer.from('fetched-image'));

--- a/test/unit/render-entrypoints.test.ts
+++ b/test/unit/render-entrypoints.test.ts
@@ -4,6 +4,7 @@ const renderMocks = vi.hoisted(() => {
   const withRenderSlot = vi.fn(async <T>(operation: () => Promise<T>): Promise<T> => operation());
   const extractMetadata = vi.fn();
   const validateMetadata = vi.fn(() => true);
+  const fetchImage = vi.fn().mockResolvedValue(Buffer.from('image'));
 
   const sharpInstance = {
     timeout: vi.fn().mockReturnThis(),
@@ -23,7 +24,7 @@ const renderMocks = vi.hoisted(() => {
     cache: vi.fn(),
   });
 
-  return { withRenderSlot, extractMetadata, validateMetadata, sharp };
+  return { withRenderSlot, extractMetadata, validateMetadata, fetchImage, sharp };
 });
 
 vi.mock('../../src/utils/render-limiter', () => ({
@@ -34,7 +35,7 @@ vi.mock('../../src/core/metadata-extractor', () => ({
   extractMetadata: renderMocks.extractMetadata,
   validateMetadata: renderMocks.validateMetadata,
   applyFallbacks: vi.fn((metadata) => metadata),
-  fetchImage: vi.fn().mockResolvedValue(Buffer.from('image')),
+  fetchImage: renderMocks.fetchImage,
   clearInflightRequests: vi.fn(),
   getInflightRequestStats: vi.fn(() => ({ active: 0 })),
 }));
@@ -62,6 +63,19 @@ const template: TemplateConfig = {
   typography: { title: { fontSize: 32 } },
 };
 
+const backgroundTemplate: TemplateConfig = {
+  ...template,
+  layout: { ...template.layout, imagePosition: 'left' },
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('render limiter entrypoints', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,6 +84,7 @@ describe('render limiter entrypoints', () => {
     );
     renderMocks.extractMetadata.mockResolvedValue({ ...metadata });
     renderMocks.validateMetadata.mockReturnValue(true);
+    renderMocks.fetchImage.mockResolvedValue(Buffer.from('image'));
     previewCache.clear();
     clearAllCaches();
   });
@@ -106,6 +121,40 @@ describe('render limiter entrypoints', () => {
     await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
 
     expect(renderMocks.withRenderSlot).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'public template renderer',
+      () =>
+        generateImageWithTemplate(
+          { ...metadata, image: 'https://example.com/background.jpg' },
+          backgroundTemplate,
+          {}
+        ),
+    ],
+    [
+      'core renderer',
+      () =>
+        generateImage(
+          { ...metadata, image: 'https://example.com/background.jpg' },
+          backgroundTemplate
+        ),
+    ],
+  ] as const)('does not acquire a render slot while %s waits for image fetch', async (_name, render) => {
+    const pendingImage = deferred<Buffer>();
+    renderMocks.fetchImage.mockReturnValueOnce(pendingImage.promise);
+
+    const rendering = render();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(renderMocks.fetchImage).toHaveBeenCalledOnce();
+    expect(renderMocks.withRenderSlot).not.toHaveBeenCalled();
+
+    pendingImage.resolve(Buffer.from('fetched-image'));
+    await rendering;
+    expect(renderMocks.withRenderSlot).toHaveBeenCalledOnce();
   });
 
 });

--- a/test/unit/render-entrypoints.test.ts
+++ b/test/unit/render-entrypoints.test.ts
@@ -1,0 +1,111 @@
+import { vi } from 'vitest';
+
+const renderMocks = vi.hoisted(() => {
+  const withRenderSlot = vi.fn(async <T>(operation: () => Promise<T>): Promise<T> => operation());
+  const extractMetadata = vi.fn();
+  const validateMetadata = vi.fn(() => true);
+
+  const sharpInstance = {
+    timeout: vi.fn().mockReturnThis(),
+    resize: vi.fn().mockReturnThis(),
+    blur: vi.fn().mockReturnThis(),
+    modulate: vi.fn().mockReturnThis(),
+    composite: vi.fn().mockReturnThis(),
+    jpeg: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    withMetadata: vi.fn().mockReturnThis(),
+    metadata: vi.fn().mockResolvedValue({ width: 320, height: 168, format: 'png' }),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from('rendered')),
+  };
+  const sharp = Object.assign(vi.fn(() => sharpInstance), {
+    concurrency: vi.fn(),
+    simd: vi.fn(),
+    cache: vi.fn(),
+  });
+
+  return { withRenderSlot, extractMetadata, validateMetadata, sharp };
+});
+
+vi.mock('../../src/utils/render-limiter', () => ({
+  withRenderSlot: renderMocks.withRenderSlot,
+}));
+vi.mock('sharp', () => ({ default: renderMocks.sharp }));
+vi.mock('../../src/core/metadata-extractor', () => ({
+  extractMetadata: renderMocks.extractMetadata,
+  validateMetadata: renderMocks.validateMetadata,
+  applyFallbacks: vi.fn((metadata) => metadata),
+  fetchImage: vi.fn().mockResolvedValue(Buffer.from('image')),
+  clearInflightRequests: vi.fn(),
+  getInflightRequestStats: vi.fn(() => ({ active: 0 })),
+}));
+
+import {
+  generateImageWithTemplate,
+  generatePreview,
+  generatePreviewFromMetadata,
+  generatePreviewFromMetadataWithDetails,
+  generatePreviewWithDetails,
+} from '../../src/index';
+import { createFallbackImage, generateImage } from '../../src/core/image-generator';
+import { clearAllCaches } from '../../src/utils/sharp-cache';
+import { previewCache, stopCacheCleanup } from '../../src/utils/cache';
+import { type ExtractedMetadata, type TemplateConfig } from '../../src/types';
+
+const metadata: ExtractedMetadata = {
+  title: 'Limiter test',
+  url: 'https://example.com/limiter',
+};
+
+const template: TemplateConfig = {
+  name: 'limiter-test',
+  layout: { padding: 20, imagePosition: 'none' },
+  typography: { title: { fontSize: 32 } },
+};
+
+describe('render limiter entrypoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    renderMocks.withRenderSlot.mockImplementation(async <T>(operation: () => Promise<T>) =>
+      operation()
+    );
+    renderMocks.extractMetadata.mockResolvedValue({ ...metadata });
+    renderMocks.validateMetadata.mockReturnValue(true);
+    previewCache.clear();
+    clearAllCaches();
+  });
+
+  afterAll(() => {
+    stopCacheCleanup();
+  });
+
+  it.each([
+    ['generateImageWithTemplate', () => generateImageWithTemplate(metadata, template, {})],
+    ['generatePreviewFromMetadata delegate', () => generatePreviewFromMetadata(metadata)],
+    ['generatePreview delegate', () => generatePreview(metadata.url)],
+    ['core generateImage', () => generateImage(metadata, template)],
+    ['fallback delegate', () => createFallbackImage(metadata.url)],
+  ] as const)('acquires exactly once for %s', async (_name, render) => {
+    await render();
+
+    expect(renderMocks.withRenderSlot).toHaveBeenCalledOnce();
+  });
+
+  it('acquires exactly once for the URL fallback render path', async () => {
+    renderMocks.extractMetadata.mockRejectedValueOnce(new Error('metadata unavailable'));
+
+    await generatePreviewWithDetails(metadata.url, { fallback: { strategy: 'generate' } });
+
+    expect(renderMocks.withRenderSlot).toHaveBeenCalledOnce();
+  });
+
+  it('does not acquire a render slot for a preview cache hit', async () => {
+    await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
+    expect(renderMocks.withRenderSlot).toHaveBeenCalledOnce();
+
+    renderMocks.withRenderSlot.mockClear();
+    await generatePreviewFromMetadataWithDetails(metadata, { cache: true });
+
+    expect(renderMocks.withRenderSlot).not.toHaveBeenCalled();
+  });
+
+});

--- a/test/unit/render-limiter.test.ts
+++ b/test/unit/render-limiter.test.ts
@@ -1,0 +1,82 @@
+import {
+  acquireRenderSlot,
+  getRenderLimiterStats,
+  resetRenderLimiterForTests,
+  withRenderSlot,
+} from '../../src/utils/render-limiter';
+import { ErrorType, PreviewGeneratorError } from '../../src/types';
+
+describe('process-wide render limiter', () => {
+  beforeEach(() => {
+    resetRenderLimiterForTests();
+  });
+
+  afterEach(() => {
+    expect(getRenderLimiterStats()).toMatchObject({ active: 0, queued: 0 });
+    resetRenderLimiterForTests();
+  });
+
+  it('runs at most four renders and admits queued work in FIFO order', async () => {
+    const activeReleases = await Promise.all(Array.from({ length: 4 }, () => acquireRenderSlot()));
+    const admitted: number[] = [];
+    const queued = [0, 1, 2].map((index) =>
+      acquireRenderSlot().then((release) => {
+        admitted.push(index);
+        return release;
+      })
+    );
+
+    expect(getRenderLimiterStats()).toMatchObject({ active: 4, queued: 3 });
+
+    activeReleases[0]();
+    const queuedRelease0 = await queued[0];
+    expect(admitted).toEqual([0]);
+
+    activeReleases[1]();
+    const queuedRelease1 = await queued[1];
+    expect(admitted).toEqual([0, 1]);
+
+    activeReleases[2]();
+    const queuedRelease2 = await queued[2];
+    expect(admitted).toEqual([0, 1, 2]);
+    expect(getRenderLimiterStats()).toMatchObject({ active: 4, queued: 0 });
+
+    activeReleases[3]();
+    queuedRelease0();
+    queuedRelease1();
+    queuedRelease2();
+  });
+
+  it('fails fast with IMAGE_ERROR after 32 queued renders', async () => {
+    const activeReleases = await Promise.all(Array.from({ length: 4 }, () => acquireRenderSlot()));
+    const queued = Array.from({ length: 32 }, () => acquireRenderSlot());
+
+    expect(getRenderLimiterStats()).toMatchObject({ active: 4, queued: 32 });
+    expect(() => acquireRenderSlot()).toThrowError(PreviewGeneratorError);
+
+    try {
+      acquireRenderSlot();
+    } catch (error) {
+      expect(error).toMatchObject({ type: ErrorType.IMAGE_ERROR });
+    }
+
+    for (const release of activeReleases) {
+      release();
+    }
+    for (const queuedRelease of queued) {
+      (await queuedRelease)();
+    }
+  });
+
+  it('releases slots after both success and failure', async () => {
+    await expect(withRenderSlot(async () => 'done')).resolves.toBe('done');
+    expect(getRenderLimiterStats()).toMatchObject({ active: 0, queued: 0 });
+
+    await expect(
+      withRenderSlot(async () => {
+        throw new Error('native failure');
+      })
+    ).rejects.toThrow('native failure');
+    expect(getRenderLimiterStats()).toMatchObject({ active: 0, queued: 0 });
+  });
+});

--- a/test/unit/render-limiter.test.ts
+++ b/test/unit/render-limiter.test.ts
@@ -52,13 +52,8 @@ describe('process-wide render limiter', () => {
     const queued = Array.from({ length: 32 }, () => acquireRenderSlot());
 
     expect(getRenderLimiterStats()).toMatchObject({ active: 4, queued: 32 });
-    expect(() => acquireRenderSlot()).toThrowError(PreviewGeneratorError);
-
-    try {
-      acquireRenderSlot();
-    } catch (error) {
-      expect(error).toMatchObject({ type: ErrorType.IMAGE_ERROR });
-    }
+    await expect(acquireRenderSlot()).rejects.toBeInstanceOf(PreviewGeneratorError);
+    await expect(acquireRenderSlot()).rejects.toMatchObject({ type: ErrorType.IMAGE_ERROR });
 
     for (const release of activeReleases) {
       release();

--- a/test/unit/render-limiter.test.ts
+++ b/test/unit/render-limiter.test.ts
@@ -1,10 +1,26 @@
 import {
+  acquireImagePreparationSlot,
   acquireRenderSlot,
   getRenderLimiterStats,
   resetRenderLimiterForTests,
+  withPreparedRenderSlot,
   withRenderSlot,
 } from '../../src/utils/render-limiter';
 import { ErrorType, PreviewGeneratorError } from '../../src/types';
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 8; index++) {
+    await Promise.resolve();
+  }
+}
 
 describe('process-wide render limiter', () => {
   beforeEach(() => {
@@ -73,5 +89,94 @@ describe('process-wide render limiter', () => {
       })
     ).rejects.toThrow('native failure');
     expect(getRenderLimiterStats()).toMatchObject({ active: 0, queued: 0 });
+  });
+
+  it('bounds image preparation before buffers can wait for render admission', async () => {
+    const preparationWork = Array.from({ length: 5 }, () => deferred());
+    const started: number[] = [];
+    const operations = preparationWork.map((work, index) =>
+      withPreparedRenderSlot(
+        async () => {
+          started.push(index);
+          await work.promise;
+          return index;
+        },
+        async prepared => prepared
+      )
+    );
+
+    await flushMicrotasks();
+    expect(started).toEqual([0, 1, 2, 3]);
+    expect(getRenderLimiterStats()).toMatchObject({ preparing: 4, preparationQueued: 1 });
+
+    preparationWork[0].resolve();
+    await expect(operations[0]).resolves.toBe(0);
+    await flushMicrotasks();
+    expect(started).toEqual([0, 1, 2, 3, 4]);
+
+    for (const work of preparationWork.slice(1)) {
+      work.resolve();
+    }
+    await Promise.all(operations.slice(1));
+  });
+
+  it('holds preparation admission until a render slot is acquired', async () => {
+    const activeRenderReleases = await Promise.all(
+      Array.from({ length: 4 }, () => acquireRenderSlot())
+    );
+    const renderWork = deferred();
+    let renderStarted = false;
+    const operation = withPreparedRenderSlot(
+      async () => 'prepared',
+      async prepared => {
+        renderStarted = true;
+        await renderWork.promise;
+        return prepared;
+      }
+    );
+
+    try {
+      await flushMicrotasks();
+      expect(renderStarted).toBe(false);
+      expect(getRenderLimiterStats()).toMatchObject({
+        active: 4,
+        queued: 1,
+        preparing: 1,
+        preparationQueued: 0,
+      });
+
+      activeRenderReleases[0]();
+      await flushMicrotasks();
+      expect(renderStarted).toBe(true);
+      expect(getRenderLimiterStats()).toMatchObject({ active: 4, preparing: 0 });
+
+      renderWork.resolve();
+      await expect(operation).resolves.toBe('prepared');
+    } finally {
+      renderWork.resolve();
+      for (const release of activeRenderReleases) {
+        release();
+      }
+      await Promise.allSettled([operation]);
+    }
+  });
+
+  it('rejects image preparation overflow as an IMAGE_ERROR promise', async () => {
+    const activeReleases = await Promise.all(
+      Array.from({ length: 4 }, () => acquireImagePreparationSlot())
+    );
+    const queued = Array.from({ length: 32 }, () => acquireImagePreparationSlot());
+
+    expect(getRenderLimiterStats()).toMatchObject({ preparing: 4, preparationQueued: 32 });
+    await expect(acquireImagePreparationSlot()).rejects.toMatchObject({
+      type: ErrorType.IMAGE_ERROR,
+    });
+
+    for (const release of activeReleases) {
+      release();
+    }
+    for (const queuedRelease of queued) {
+      (await queuedRelease)();
+    }
   });
 });

--- a/test/unit/sharp-security.test.ts
+++ b/test/unit/sharp-security.test.ts
@@ -6,7 +6,6 @@
 import { 
   initializeSharpSecurity, 
   validateImageBuffer, 
-  processImageWithTimeout,
   createSecureSharpInstance,
   createSecureSharpWithCleanMetadata,
   validateSharpLimits,
@@ -50,35 +49,6 @@ describe('Sharp Security Configuration - Enhanced', () => {
     it('should allow operations within limits', () => {
       expect(() => validateSharpLimits(1920, 1080)).not.toThrow();
       expect(() => validateSharpLimits(4096, 4096)).not.toThrow();
-    });
-  });
-
-  describe('Timeout protection', () => {
-    it('should timeout long-running operations', async () => {
-      let timer: NodeJS.Timeout | undefined;
-      const slowOperation = () => new Promise<string>(resolve => {
-        timer = setTimeout(() => resolve('done'), 5000); // 5 seconds
-        timer.unref?.();
-      });
-
-      await expect(
-        processImageWithTimeout(slowOperation, 100) // 100ms timeout
-      ).rejects.toThrow('timed out');
-
-      if (timer) clearTimeout(timer);
-    }, 10000);
-
-    it('should complete fast operations normally', async () => {
-      const fastOperation = () => Promise.resolve('completed');
-
-      const result = await processImageWithTimeout(fastOperation, 1000);
-      expect(result).toBe('completed');
-    });
-
-    it('should use default timeout when not specified', async () => {
-      const operation = () => Promise.resolve('default');
-      const result = await processImageWithTimeout(operation);
-      expect(result).toBe('default');
     });
   });
 

--- a/test/unit/sharp-timeout.test.ts
+++ b/test/unit/sharp-timeout.test.ts
@@ -1,0 +1,95 @@
+import { vi } from 'vitest';
+
+const sharpMockState = vi.hoisted(() => {
+  const instances: Array<{
+    timeout: ReturnType<typeof vi.fn>;
+    withMetadata: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  const sharp = vi.fn(() => {
+    const instance = {
+      timeout: vi.fn(),
+      withMetadata: vi.fn(),
+    };
+    instance.timeout.mockReturnValue(instance);
+    instance.withMetadata.mockReturnValue(instance);
+    instances.push(instance);
+    return instance;
+  });
+
+  return { sharp, instances };
+});
+
+vi.mock('sharp', () => ({ default: sharpMockState.sharp }));
+
+import {
+  createSecureSharpInstance,
+  createSecureSharpWithCleanMetadata,
+  withSecureSharp,
+  withSecureSharpCleanMetadata,
+} from '../../src/utils/image-security';
+import {
+  clearAllCaches,
+  createCachedCanvas,
+  createCachedSVG,
+} from '../../src/utils/sharp-cache';
+import { createTransparentCanvas } from '../../src/utils/validators/canvas';
+import { isSharpProcessingTimeout } from '../../src/utils/sharp-timeout';
+import { ErrorType, PreviewGeneratorError } from '../../src/types';
+
+function expectNativeTimeoutOnEveryCreatedInstance(): void {
+  expect(sharpMockState.instances.length).toBeGreaterThan(0);
+  for (const instance of sharpMockState.instances) {
+    expect(instance.timeout).toHaveBeenCalledOnce();
+    expect(instance.timeout).toHaveBeenCalledWith({ seconds: 30 });
+  }
+}
+
+describe('native Sharp processing timeout', () => {
+  beforeEach(() => {
+    sharpMockState.sharp.mockClear();
+    sharpMockState.instances.length = 0;
+    clearAllCaches();
+  });
+
+  it('covers every output-capable untrusted raster factory', async () => {
+    const buffer = Buffer.from('raster');
+
+    createSecureSharpInstance(buffer);
+    await withSecureSharp(buffer, async (instance) => instance);
+    createSecureSharpWithCleanMetadata(buffer);
+    await withSecureSharpCleanMetadata(buffer, async (instance) => instance);
+
+    expect(sharpMockState.instances).toHaveLength(4);
+    expectNativeTimeoutOnEveryCreatedInstance();
+  });
+
+  it('covers SVG and canvas cache misses and hits', async () => {
+    const svg = '<svg width="1" height="1" xmlns="http://www.w3.org/2000/svg" />';
+    const canvasOptions = { colors: { background: '#000000', accent: '#ffffff' } };
+
+    await createCachedSVG(svg);
+    await createCachedSVG(svg);
+    await createCachedCanvas(320, 168, canvasOptions);
+    await createCachedCanvas(320, 168, canvasOptions);
+
+    expect(sharpMockState.instances).toHaveLength(4);
+    expectNativeTimeoutOnEveryCreatedInstance();
+  });
+
+  it('covers transparent canvas creation', () => {
+    createTransparentCanvas(320, 168);
+
+    expect(sharpMockState.instances).toHaveLength(1);
+    expectNativeTimeoutOnEveryCreatedInstance();
+  });
+
+  it('recognizes native libvips timeouts through wrapped error details', () => {
+    const nativeTimeout = new Error('timeout: 27% complete');
+    const wrapped = new PreviewGeneratorError(ErrorType.IMAGE_ERROR, 'render failed', nativeTimeout);
+
+    expect(isSharpProcessingTimeout(nativeTimeout)).toBe(true);
+    expect(isSharpProcessingTimeout(wrapped)).toBe(true);
+    expect(isSharpProcessingTimeout(new Error('network request timed out'))).toBe(false);
+  });
+});

--- a/test/unit/template-image-processing.test.ts
+++ b/test/unit/template-image-processing.test.ts
@@ -11,6 +11,7 @@ import { modernTemplate } from '../../src/templates/modern';
 // Mock sharp to test configuration without actual image processing
 vi.mock('sharp', () => {
   const mockSharp = {
+    timeout: vi.fn().mockReturnThis(),
     resize: vi.fn().mockReturnThis(),
     blur: vi.fn().mockReturnThis(),
     modulate: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary
- apply Sharp native 30-second timeouts to every output-capable pipeline
- add a process-wide FIFO render limiter with 4 active and 32 queued renders
- avoid retrying timed-out background pipelines and remove the ineffective Promise-only timeout wrapper
- preserve existing custom-template metadata behavior and public exports

## Verification
- pnpm run lint
- pnpm test (30 files, 521 tests)
- pnpm run build
- pnpm run verify:release -- --tag v0.2.6
- pnpm run verify:package
- representative 1200x630 progressive JPEG inspected successfully
- git diff --check