### PR TITLE
fix(security): propagate URL policy violations

### DIFF
--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -49,6 +49,38 @@ function getNetworkControlErrorMessage(error: unknown): string | undefined {
   return undefined;
 }
 
+function findValidationError(error: unknown): PreviewGeneratorError | undefined {
+  const pending: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (pending.length > 0 && visited.size < 16) {
+    const current = pending.shift();
+    if (current === null || current === undefined || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    if (
+      current instanceof PreviewGeneratorError &&
+      current.type === ErrorType.VALIDATION_ERROR
+    ) {
+      return current;
+    }
+
+    if (typeof current === 'object') {
+      const nested = current as { cause?: unknown; details?: unknown };
+      if (nested.cause !== undefined) {
+        pending.push(nested.cause);
+      }
+      if (nested.details !== undefined) {
+        pending.push(nested.details);
+      }
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Build redirect validation callback for SSRF protection
  */
@@ -318,6 +350,18 @@ async function validateUrlSecurity(
     // Enhanced security validation with TOCTOU protection
     const securityValidation = await validateRequestSecurity(validatedUrl, abortSignal);
     if (!securityValidation.allowed) {
+      if (securityValidation.failureKind === 'operational') {
+        throw new PreviewGeneratorError(
+          ErrorType.FETCH_ERROR,
+          `Failed to validate URL security: ${securityValidation.reason}`,
+          {
+            url: validatedUrl,
+            blockedIPs: securityValidation.blockedIPs,
+            allowedIPs: securityValidation.allowedIPs
+          }
+        );
+      }
+
       throw new PreviewGeneratorError(
         ErrorType.VALIDATION_ERROR,
         `URL blocked by security validation: ${securityValidation.reason}`,
@@ -393,11 +437,9 @@ async function fetchOpenGraphData(
     html = fetched.response.data;
     validatedUrl = fetched.validatedUrl;
   } catch (fetchError) {
-    if (
-      fetchError instanceof PreviewGeneratorError &&
-      fetchError.type === ErrorType.VALIDATION_ERROR
-    ) {
-      throw fetchError;
+    const validationError = findValidationError(fetchError);
+    if (validationError) {
+      throw validationError;
     }
     // Network-level failure — no HTML to parse, fail immediately without retry
     const controlMessage = getNetworkControlErrorMessage(fetchError);
@@ -605,6 +647,11 @@ export async function fetchImage(imageUrl: string, securityOptions?: SecurityOpt
 
     return validatedImageBuffer;
   } catch (error) {
+    const validationError = findValidationError(error);
+    if (validationError) {
+      throw validationError;
+    }
+
     throw new PreviewGeneratorError(
       ErrorType.IMAGE_ERROR,
       `Failed to fetch image from ${imageUrl}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -23,6 +23,7 @@ import {
   NetworkRequestQueueFullError,
   runControlledNetworkRequest,
 } from '../utils/network-request-control';
+import { createSecurityPolicyError } from '../utils/security-policy-error';
 
 // Allowed MIME types for images
 const BASE_ALLOWED_MIME_TYPES = new Set([
@@ -90,8 +91,7 @@ function createRedirectValidator(context: string, httpsOnly: boolean = false) {
     _responseDetails: { headers: Record<string, string>; statusCode: number }
   ) => {
     if (typeof options.href !== 'string' || options.href.length === 0) {
-      throw new PreviewGeneratorError(
-        ErrorType.VALIDATION_ERROR,
+      throw createSecurityPolicyError(
         `${context} blocked: canonical redirect URL is missing`
       );
     }
@@ -101,16 +101,14 @@ function createRedirectValidator(context: string, httpsOnly: boolean = false) {
     try {
       validatedRedirectUrl = validateUrlInput(redirectUrl);
     } catch (error) {
-      throw new PreviewGeneratorError(
-        ErrorType.VALIDATION_ERROR,
+      throw createSecurityPolicyError(
         `${context} to unsafe URL blocked: ${redirectUrl}`,
         error
       );
     }
 
     if (httpsOnly && new URL(validatedRedirectUrl).protocol !== 'https:') {
-      throw new PreviewGeneratorError(
-        ErrorType.VALIDATION_ERROR,
+      throw createSecurityPolicyError(
         `${context} blocked by HTTPS-only mode: ${validatedRedirectUrl}`
       );
     }
@@ -329,7 +327,9 @@ function validateUrlBeforeNetwork(url: string, securityOptions?: SecurityOptions
 
     // Check HTTPS-only requirement
     if (securityOptions?.httpsOnly && urlObj.protocol !== 'https:') {
-      throw new Error('HTTP URLs are not allowed when HTTPS-only mode is enabled.');
+      throw createSecurityPolicyError(
+        'HTTP URLs are not allowed when HTTPS-only mode is enabled.'
+      );
     }
 
     return urlObj.toString();
@@ -362,8 +362,7 @@ async function validateUrlSecurity(
         );
       }
 
-      throw new PreviewGeneratorError(
-        ErrorType.VALIDATION_ERROR,
+      throw createSecurityPolicyError(
         `URL blocked by security validation: ${securityValidation.reason}`,
         {
           url: validatedUrl,

--- a/src/core/template-image-processing.ts
+++ b/src/core/template-image-processing.ts
@@ -1,5 +1,11 @@
 import type { Sharp } from 'sharp';
-import { ExtractedMetadata, TemplateConfig, SanitizedOptions } from '../types';
+import {
+  ErrorType,
+  ExtractedMetadata,
+  PreviewGeneratorError,
+  SanitizedOptions,
+  TemplateConfig,
+} from '../types';
 import { createTransparentCanvas } from '../utils/validators';
 import { logImageFetchError } from '../utils/logger';
 import { secureResize, withSecureSharp } from '../utils/image-security';
@@ -33,6 +39,13 @@ export async function prepareImageForTemplate(
     const imageBuffer = await fetchImage(metadata.image, options.security);
     return { effectiveMetadata, imageBuffer };
   } catch (fetchError) {
+    if (
+      fetchError instanceof PreviewGeneratorError &&
+      fetchError.type === ErrorType.VALIDATION_ERROR
+    ) {
+      throw fetchError;
+    }
+
     logImageFetchError(
       metadata.image,
       fetchError instanceof Error ? fetchError : new Error(String(fetchError))

--- a/src/core/template-image-processing.ts
+++ b/src/core/template-image-processing.ts
@@ -1,8 +1,6 @@
 import type { Sharp } from 'sharp';
 import {
-  ErrorType,
   ExtractedMetadata,
-  PreviewGeneratorError,
   SanitizedOptions,
   TemplateConfig,
 } from '../types';
@@ -11,6 +9,7 @@ import { logImageFetchError } from '../utils/logger';
 import { secureResize, withSecureSharp } from '../utils/image-security';
 import { fetchImage } from './metadata-extractor';
 import { createBlankCanvas } from './image-generator';
+import { isSecurityPolicyError } from '../utils/security-policy-error';
 
 export interface ProcessedTemplateImage {
   baseImage: Sharp;
@@ -39,10 +38,7 @@ export async function prepareImageForTemplate(
     const imageBuffer = await fetchImage(metadata.image, options.security);
     return { effectiveMetadata, imageBuffer };
   } catch (fetchError) {
-    if (
-      fetchError instanceof PreviewGeneratorError &&
-      fetchError.type === ErrorType.VALIDATION_ERROR
-    ) {
+    if (isSecurityPolicyError(fetchError)) {
       throw fetchError;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,6 +375,16 @@ export async function generatePreviewWithDetails(
         metadata = applyFallbacks(metadata, url);
       }
     } catch (error) {
+      // Input and security-policy violations must remain observable to callers.
+      // Falling back here would turn a rejected URL (for example, HTTP in
+      // HTTPS-only mode or a blocked SSRF target) into a successful response.
+      if (
+        error instanceof PreviewGeneratorError &&
+        error.type === ErrorType.VALIDATION_ERROR
+      ) {
+        throw error;
+      }
+
       // If metadata extraction fails completely, use fallback
       if (
         finalOptions.fallback?.strategy === 'generate' ||

--- a/src/utils/enhanced-secure-agent.ts
+++ b/src/utils/enhanced-secure-agent.ts
@@ -13,6 +13,7 @@ import tls from 'tls';
 import { isPrivateOrReservedIP } from './ip-validation';
 import { logger } from './logger';
 import { SECURITY_CONFIG } from '../constants/security';
+import { ErrorType, PreviewGeneratorError } from '../types';
 
 interface CachedDNSResult {
   addresses: dns.LookupAddress[];
@@ -26,6 +27,7 @@ interface SecurityValidationResult {
   blockedIPs: string[];
   allowedIPs: string[];
   reason?: string;
+  failureKind?: 'policy' | 'operational';
 }
 
 const MAX_ACTIVE_DNS_LOOKUPS = 8;
@@ -48,6 +50,17 @@ function createDNSLookupError(message: string, code: string): NodeJS.ErrnoExcept
   const error = new Error(message) as NodeJS.ErrnoException;
   error.code = code;
   error.syscall = 'getaddrinfo';
+  return error;
+}
+
+function createNetworkPolicyError(
+  message: string
+): PreviewGeneratorError & NodeJS.ErrnoException {
+  const error = new PreviewGeneratorError(
+    ErrorType.VALIDATION_ERROR,
+    message
+  ) as PreviewGeneratorError & NodeJS.ErrnoException;
+  error.code = 'ECONNREFUSED';
   return error;
 }
 
@@ -415,6 +428,7 @@ function validateIPAddresses(addresses: dns.LookupAddress[]): SecurityValidation
     allowed: blockedIPs.length === 0,
     blockedIPs,
     allowedIPs,
+    failureKind: blockedIPs.length > 0 ? 'policy' : undefined,
     reason: blockedIPs.length > 0 
       ? `Blocked private or reserved IPs: ${blockedIPs.join(', ')}`
       : undefined
@@ -460,11 +474,10 @@ const enhancedSecureLookup = (
           allowedIPs: validation.allowedIPs
         });
 
-        const securityError = new Error(
+        const securityError = createNetworkPolicyError(
           `Connection blocked: ${validation.reason}. ` +
           `Total resolved: ${addresses.length}, blocked: ${validation.blockedIPs.length}`
-        ) as NodeJS.ErrnoException;
-        securityError.code = 'ECONNREFUSED';
+        );
 
         // Never return actual IPs in security errors - use placeholder values
         return actualCallback(securityError, '0.0.0.0', 4);
@@ -477,10 +490,9 @@ const enhancedSecureLookup = (
       
       // If no safe address found, this is a critical error
       if (!firstSafeAddress) {
-        const criticalError = new Error(
+        const criticalError = createNetworkPolicyError(
           `Critical security error: No safe addresses found for ${hostname}`
-        ) as NodeJS.ErrnoException;
-        criticalError.code = 'ECONNREFUSED';
+        );
         return actualCallback(criticalError, '0.0.0.0', 4);
       }
 
@@ -605,7 +617,7 @@ export function createEnhancedSecureHttpAgent(): http.Agent {
     socket.on('connect', () => {
       // Perform socket-level IP validation after connection
       if (!validateSocketIP(socket as net.Socket, hostname)) {
-        const validationError = new Error(
+        const validationError = createNetworkPolicyError(
           `Connection rejected: socket IP validation failed for ${hostname}`
         );
         logger.warn('TOCTOU protection triggered: destroying connection', {
@@ -674,7 +686,7 @@ export function createEnhancedSecureHttpsAgent(): https.Agent {
     socket.on('secureConnect', () => {
       // Perform socket-level IP validation after TLS connection
       if (!validateSocketIP(socket as tls.TLSSocket, hostname)) {
-        const validationError = new Error(
+        const validationError = createNetworkPolicyError(
           `TLS connection rejected: socket IP validation failed for ${hostname}`
         );
         logger.warn('TOCTOU protection triggered: destroying TLS connection', {
@@ -777,6 +789,7 @@ export async function validateRequestSecurity(
       allowed: false,
       blockedIPs: [],
       allowedIPs: [],
+      failureKind: 'operational',
       reason: `Security validation error: ${(error as Error).message}`
     };
   }

--- a/src/utils/enhanced-secure-agent.ts
+++ b/src/utils/enhanced-secure-agent.ts
@@ -13,7 +13,8 @@ import tls from 'tls';
 import { isPrivateOrReservedIP } from './ip-validation';
 import { logger } from './logger';
 import { SECURITY_CONFIG } from '../constants/security';
-import { ErrorType, PreviewGeneratorError } from '../types';
+import { PreviewGeneratorError } from '../types';
+import { createSecurityPolicyError } from './security-policy-error';
 
 interface CachedDNSResult {
   addresses: dns.LookupAddress[];
@@ -56,8 +57,7 @@ function createDNSLookupError(message: string, code: string): NodeJS.ErrnoExcept
 function createNetworkPolicyError(
   message: string
 ): PreviewGeneratorError & NodeJS.ErrnoException {
-  const error = new PreviewGeneratorError(
-    ErrorType.VALIDATION_ERROR,
+  const error = createSecurityPolicyError(
     message
   ) as PreviewGeneratorError & NodeJS.ErrnoException;
   error.code = 'ECONNREFUSED';

--- a/src/utils/security-policy-error.ts
+++ b/src/utils/security-policy-error.ts
@@ -1,0 +1,31 @@
+import { ErrorType, PreviewGeneratorError } from '../types';
+
+interface SecurityPolicyErrorDetails {
+  securityPolicyViolation: true;
+  cause?: unknown;
+}
+
+export function createSecurityPolicyError(
+  message: string,
+  cause?: unknown
+): PreviewGeneratorError {
+  return new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, message, {
+    securityPolicyViolation: true,
+    cause,
+  } satisfies SecurityPolicyErrorDetails);
+}
+
+export function isSecurityPolicyError(error: unknown): error is PreviewGeneratorError {
+  if (
+    !(error instanceof PreviewGeneratorError) ||
+    error.type !== ErrorType.VALIDATION_ERROR ||
+    !error.details ||
+    typeof error.details !== 'object'
+  ) {
+    return false;
+  }
+
+  return (
+    (error.details as Partial<SecurityPolicyErrorDetails>).securityPolicyViolation === true
+  );
+}

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -587,6 +587,21 @@ describe('End-to-End Integration Tests', () => {
       });
       expect(mockedAxios.get).not.toHaveBeenCalled();
     });
+
+    it.each(['auto', 'generate'] as const)(
+      'should not turn an HTTPS-only policy violation into a %s fallback success',
+      async strategy => {
+        await expect(
+          generatePreviewWithDetails('http://policy-violation.example/path', {
+            fallback: { strategy },
+            security: { httpsOnly: true },
+          })
+        ).rejects.toMatchObject({
+          type: ErrorType.VALIDATION_ERROR,
+        });
+        expect(mockedAxios.get).not.toHaveBeenCalled();
+      }
+    );
   });
 
   describe('generatePreviewFromMetadata', () => {

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -13,6 +13,7 @@ import ogs from 'open-graph-scraper';
 import sharp from 'sharp';
 import { metadataCache } from '../../src/utils/cache';
 import { templates } from '../../src/templates/registry';
+import { validateRequestSecurity } from '../../src/utils/enhanced-secure-agent';
 
 vi.mock('axios');
 vi.mock('open-graph-scraper');
@@ -31,6 +32,7 @@ vi.mock('../../src/utils/enhanced-secure-agent', () => ({
 const mockedAxios = axios as vi.Mocked<typeof axios>;
 const mockedOgs = ogs as vi.MockedFunction<typeof ogs>;
 const mockedSharp = sharp as vi.MockedFunction<typeof sharp>;
+const mockedValidateRequestSecurity = vi.mocked(validateRequestSecurity);
 
 describe('End-to-End Integration Tests', () => {
   beforeEach(() => {
@@ -39,6 +41,11 @@ describe('End-to-End Integration Tests', () => {
     // (clearAllMocks only clears call data, not once-value queues)
     mockedAxios.get.mockReset();
     mockedOgs.mockReset();
+    mockedValidateRequestSecurity.mockReset().mockResolvedValue({
+      allowed: true,
+      blockedIPs: [],
+      allowedIPs: [],
+    });
     clearAllCaches();
     clearInflightRequests();
     metadataCache.clear();
@@ -600,6 +607,59 @@ describe('End-to-End Integration Tests', () => {
           type: ErrorType.VALIDATION_ERROR,
         });
         expect(mockedAxios.get).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(['auto', 'generate'] as const)(
+      'should preserve the %s fallback for operational DNS failures',
+      async strategy => {
+        mockedValidateRequestSecurity.mockResolvedValueOnce({
+          allowed: false,
+          blockedIPs: [],
+          allowedIPs: [],
+          reason: 'Security validation error: getaddrinfo ENOTFOUND',
+          failureKind: 'operational',
+        } as Awaited<ReturnType<typeof validateRequestSecurity>>);
+
+        const result = await generatePreviewWithDetails('https://dns-failure.example/path', {
+          fallback: { strategy },
+        });
+
+        expect(result).toMatchObject({ template: 'fallback', cached: false });
+        expect(mockedAxios.get).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(['auto', 'generate'] as const)(
+      'should not turn a wrapped HTTPS-only redirect violation into a %s fallback success',
+      async strategy => {
+        mockedAxios.get.mockImplementationOnce(async (_url, config) => {
+          let policyError: unknown;
+          try {
+            config?.beforeRedirect?.(
+              {
+                protocol: 'http:',
+                hostname: 'redirect.example',
+                href: 'http://redirect.example/path',
+              },
+              { headers: {}, statusCode: 302 }
+            );
+          } catch (error) {
+            policyError = error;
+          }
+
+          const redirectError = Object.assign(new Error('Redirected request failed'), {
+            cause: policyError,
+          });
+          throw Object.assign(new Error('Axios request failed'), { cause: redirectError });
+        });
+
+        await expect(
+          generatePreviewWithDetails('https://safe-origin.example/path', {
+            fallback: { strategy },
+            security: { httpsOnly: true },
+          })
+        ).rejects.toMatchObject({ type: ErrorType.VALIDATION_ERROR });
       }
     );
   });

--- a/test/unit/enhanced-secure-agent.test.ts
+++ b/test/unit/enhanced-secure-agent.test.ts
@@ -32,6 +32,7 @@ vi.mock('../../src/utils/ip-validation', () => ({
 }));
 
 import { isPrivateOrReservedIP } from '../../src/utils/ip-validation';
+import { ErrorType, PreviewGeneratorError } from '../../src/types';
 const mockIsPrivateOrReservedIP = isPrivateOrReservedIP as vi.MockedFunction<typeof isPrivateOrReservedIP>;
 
 async function useProductionIPClassifier(): Promise<void> {
@@ -484,6 +485,7 @@ describe('Enhanced Secure Agent', () => {
       const result = await validateRequestSecurity('https://mixed.com/test');
       
       expect(result.allowed).toBe(false);
+      expect(result.failureKind).toBe('policy');
       expect(result.blockedIPs).toContain('192.168.1.1');
       expect(result.allowedIPs).toContain('8.8.8.8');
       expect(result.allowedIPs).toContain('1.1.1.1');
@@ -513,11 +515,44 @@ describe('Enhanced Secure Agent', () => {
       const result = await validateRequestSecurity('https://nonexistent.invalid/test');
       
       expect(result.allowed).toBe(false);
+      expect(result.failureKind).toBe('operational');
       expect(result.reason).toContain('Security validation error');
     });
   });
 
   describe('Agent Configuration', () => {
+    it('marks blocked DNS lookup callbacks as validation policy errors', async () => {
+      const cleanup = mockDNSLookup('private-redirect.example', [
+        { address: '192.168.1.1', family: 4 },
+      ]);
+
+      try {
+        await useProductionIPClassifier();
+        const agent = createEnhancedSecureHttpAgent();
+        const lookup = (agent as unknown as {
+          options: {
+            lookup: (
+              hostname: string,
+              options: dns.LookupOneOptions,
+              callback: (error: NodeJS.ErrnoException | null) => void
+            ) => void;
+          };
+        }).options.lookup;
+
+        const error = await new Promise<NodeJS.ErrnoException | null>(resolve => {
+          lookup('private-redirect.example', {}, resolve);
+        });
+
+        expect(error).toBeInstanceOf(PreviewGeneratorError);
+        expect(error).toMatchObject({
+          type: ErrorType.VALIDATION_ERROR,
+          code: 'ECONNREFUSED',
+        });
+      } finally {
+        cleanup();
+      }
+    });
+
     it('should create HTTP agent with security settings', () => {
       const agent = createEnhancedSecureHttpAgent();
       

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import { extractMetadata, validateMetadata, applyFallbacks, fetchImage } from '../../src/core/metadata-extractor';
-import { ErrorType, ExtractedMetadata } from '../../src/types';
+import { ErrorType, ExtractedMetadata, PreviewGeneratorError } from '../../src/types';
 import { mockHtmlWithOg, mockHtmlMinimal, mockHtmlWithTwitter } from '../fixtures/mock-html';
 import axios from 'axios';
 import ogs from 'open-graph-scraper';
@@ -71,6 +71,38 @@ describe('Metadata Extractor', () => {
       expect(mockedValidateRequestSecurity).toHaveBeenCalledWith(
         new URL(testUrl).toString(),
         expect.any(AbortSignal)
+      );
+    });
+
+    it('should classify operational DNS validation failures as fetch errors', async () => {
+      mockedValidateRequestSecurity.mockResolvedValueOnce({
+        allowed: false,
+        blockedIPs: [],
+        allowedIPs: [],
+        reason: 'Security validation error: getaddrinfo ENOTFOUND',
+        failureKind: 'operational',
+      } as Awaited<ReturnType<typeof validateRequestSecurity>>);
+
+      await expect(extractMetadata('https://dns-failure.example/path')).rejects.toMatchObject({
+        type: ErrorType.FETCH_ERROR,
+      });
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    it('should restore socket policy violations wrapped by the HTTP client', async () => {
+      const policyError = new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        'Connection blocked: private redirect target'
+      );
+      const transportError = Object.assign(new Error('Redirect request failed'), {
+        cause: policyError,
+      });
+      mockedAxios.get.mockRejectedValueOnce(
+        Object.assign(new Error('Axios request failed'), { cause: transportError })
+      );
+
+      await expect(extractMetadata('https://redirect-origin.example/path')).rejects.toBe(
+        policyError
       );
     });
 

--- a/test/unit/render-entrypoints.test.ts
+++ b/test/unit/render-entrypoints.test.ts
@@ -67,7 +67,12 @@ import {
 import { createFallbackImage, generateImage } from '../../src/core/image-generator';
 import { clearAllCaches } from '../../src/utils/sharp-cache';
 import { previewCache, stopCacheCleanup } from '../../src/utils/cache';
-import { type ExtractedMetadata, type TemplateConfig } from '../../src/types';
+import {
+  ErrorType,
+  PreviewGeneratorError,
+  type ExtractedMetadata,
+  type TemplateConfig,
+} from '../../src/types';
 
 const metadata: ExtractedMetadata = {
   title: 'Limiter test',
@@ -182,6 +187,24 @@ describe('render limiter entrypoints', () => {
     pendingImage.resolve(Buffer.from('fetched-image'));
     await rendering;
     expect(renderMocks.withRenderSlot).toHaveBeenCalledOnce();
+  });
+
+  it('propagates background-image security policy violations', async () => {
+    renderMocks.fetchImage.mockRejectedValueOnce(
+      new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        'Image redirect blocked by HTTPS-only mode'
+      )
+    );
+
+    await expect(
+      generateImageWithTemplate(
+        { ...metadata, image: 'https://example.com/background.jpg' },
+        backgroundTemplate,
+        { security: { httpsOnly: true } }
+      )
+    ).rejects.toMatchObject({ type: ErrorType.VALIDATION_ERROR });
+    expect(renderMocks.withRenderSlot).not.toHaveBeenCalled();
   });
 
 });

--- a/test/unit/render-entrypoints.test.ts
+++ b/test/unit/render-entrypoints.test.ts
@@ -73,6 +73,7 @@ import {
   type ExtractedMetadata,
   type TemplateConfig,
 } from '../../src/types';
+import { createSecurityPolicyError } from '../../src/utils/security-policy-error';
 
 const metadata: ExtractedMetadata = {
   title: 'Limiter test',
@@ -191,8 +192,7 @@ describe('render limiter entrypoints', () => {
 
   it('propagates background-image security policy violations', async () => {
     renderMocks.fetchImage.mockRejectedValueOnce(
-      new PreviewGeneratorError(
-        ErrorType.VALIDATION_ERROR,
+      createSecurityPolicyError(
         'Image redirect blocked by HTTPS-only mode'
       )
     );
@@ -205,6 +205,21 @@ describe('render limiter entrypoints', () => {
       )
     ).rejects.toMatchObject({ type: ErrorType.VALIDATION_ERROR });
     expect(renderMocks.withRenderSlot).not.toHaveBeenCalled();
+  });
+
+  it('renders without a malformed scraped background image', async () => {
+    renderMocks.fetchImage.mockRejectedValueOnce(
+      new PreviewGeneratorError(ErrorType.VALIDATION_ERROR, 'Invalid URL: https://')
+    );
+
+    await expect(
+      generateImageWithTemplate(
+        { ...metadata, image: 'https://' },
+        backgroundTemplate,
+        {}
+      )
+    ).resolves.toEqual(Buffer.from('rendered'));
+    expect(renderMocks.withRenderSlot).toHaveBeenCalledOnce();
   });
 
 });


### PR DESCRIPTION
## Summary
- keep URL, HTTPS-only, redirect, DNS/private-IP, and socket policy violations observable instead of returning successful fallbacks
- distinguish operational DNS failures as FETCH_ERROR so auto/generate fallback remains available
- recover policy errors through Axios/follow-redirects cause chains
- preserve image-less rendering for malformed scraped images while propagating actual image security-policy violations

## Verification
- focused policy/IP/render tests (5 files, 241 tests)
- pnpm run lint
- pnpm test (30 files, 568 tests)
- pnpm run build
- git diff --check
- rebased onto #72; NAT64/SRv6 ranges confirmed present
- local adversarial re-review: clean