### PR TITLE
fix(security): validate runtime security options

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,7 +57,7 @@ export interface SecurityOptions {
   httpsOnly?: boolean;
   /** Allow SVG images (disabled by default for security) */
   allowSvg?: boolean;
-  /** Maximum allowed redirects (default: 3) */
+  /** Maximum allowed redirects, integer 0-10 (default: 3) */
   maxRedirects?: number;
   /** Request timeout in milliseconds, integer 1-30000 (default: 8000 for HTML, 12000 for images) */
   timeout?: number;

--- a/src/utils/validators/options.ts
+++ b/src/utils/validators/options.ts
@@ -10,6 +10,17 @@ import { validateTextInput } from './text';
 
 const MIN_REQUEST_TIMEOUT_MS = 1;
 const MAX_REQUEST_TIMEOUT_MS = 30_000;
+const MIN_REDIRECTS = 0;
+const MAX_REDIRECTS = 10;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
 
 /**
  * Validates all preview options including dimensions, quality, and colors.
@@ -38,8 +49,22 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
   if (options.fallback) {
     sanitized.fallback = { ...options.fallback };
   }
+  if (options.security !== undefined && !isPlainObject(options.security)) {
+    throw new PreviewGeneratorError(
+      ErrorType.VALIDATION_ERROR,
+      'Security options must be a plain object'
+    );
+  }
   if (options.security) {
-    sanitized.security = { ...options.security };
+    // Keep only the documented security surface. Unknown runtime keys must not
+    // become part of metadata cache keys or retain attacker-controlled data.
+    const knownSecurity: Record<string, unknown> = {};
+    for (const field of ['httpsOnly', 'allowSvg', 'maxRedirects', 'timeout'] as const) {
+      if (Object.hasOwn(options.security, field)) {
+        knownSecurity[field] = options.security[field];
+      }
+    }
+    sanitized.security = knownSecurity as PreviewOptions['security'];
   }
   if (options.fonts !== undefined) {
     if (!Array.isArray(options.fonts)) {
@@ -141,6 +166,32 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
       throw new PreviewGeneratorError(
         ErrorType.VALIDATION_ERROR,
         `Security timeout must be between ${MIN_REQUEST_TIMEOUT_MS} and ${MAX_REQUEST_TIMEOUT_MS} milliseconds`
+      );
+    }
+  }
+
+  for (const field of ['allowSvg', 'httpsOnly'] as const) {
+    const value = sanitized.security?.[field];
+    if (value !== undefined && typeof value !== 'boolean') {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        `Security ${field} must be boolean, got: ${typeof value}`
+      );
+    }
+  }
+
+  if (sanitized.security?.maxRedirects !== undefined) {
+    const maxRedirects = sanitized.security.maxRedirects;
+    if (
+      typeof maxRedirects !== 'number' ||
+      !Number.isFinite(maxRedirects) ||
+      !Number.isInteger(maxRedirects) ||
+      maxRedirects < MIN_REDIRECTS ||
+      maxRedirects > MAX_REDIRECTS
+    ) {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        `Security maxRedirects must be a finite integer between ${MIN_REDIRECTS} and ${MAX_REDIRECTS}`
       );
     }
   }

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -571,6 +571,22 @@ describe('End-to-End Integration Tests', () => {
         expect(mockedAxios.get).not.toHaveBeenCalled();
       }
     );
+
+    it.each([
+      { allowSvg: 'false' },
+      { httpsOnly: 'false' },
+      { maxRedirects: -1 },
+      { maxRedirects: 11 },
+    ])('should reject unsafe public security options before network I/O: %o', async security => {
+      await expect(
+        generatePreview('https://security-option-validation.example', {
+          security,
+        } as unknown as PreviewOptions)
+      ).rejects.toMatchObject({
+        type: ErrorType.VALIDATION_ERROR,
+      });
+      expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('generatePreviewFromMetadata', () => {

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -268,6 +268,73 @@ describe('Validators', () => {
         expect(sanitizeOptions({ security: { timeout } }).security?.timeout).toBe(timeout);
       }
     );
+
+    test.each([
+      ['allowSvg', 'false'],
+      ['allowSvg', 1],
+      ['httpsOnly', 'false'],
+      ['httpsOnly', 0],
+    ] as const)(
+      'should reject non-boolean security option %s=%s with VALIDATION_ERROR',
+      (field, value) => {
+        try {
+          sanitizeOptions({
+            security: { [field]: value },
+          } as unknown as PreviewOptions);
+          throw new Error(`Expected sanitizeOptions to reject security.${field}`);
+        } catch (error) {
+          expect(error).toBeInstanceOf(PreviewGeneratorError);
+          expect((error as PreviewGeneratorError).type).toBe(ErrorType.VALIDATION_ERROR);
+          expect((error as PreviewGeneratorError).message).toContain(`Security ${field}`);
+        }
+      }
+    );
+
+    test.each([NaN, Infinity, -1, 1.5, 11, '3' as unknown as number])(
+      'should reject invalid maxRedirects %s with VALIDATION_ERROR',
+      maxRedirects => {
+        try {
+          sanitizeOptions({ security: { maxRedirects } });
+          throw new Error('Expected sanitizeOptions to reject security.maxRedirects');
+        } catch (error) {
+          expect(error).toBeInstanceOf(PreviewGeneratorError);
+          expect((error as PreviewGeneratorError).type).toBe(ErrorType.VALIDATION_ERROR);
+          expect((error as PreviewGeneratorError).message).toContain('Security maxRedirects');
+        }
+      }
+    );
+
+    test.each([0, 3, 10])('should preserve valid maxRedirects %i', maxRedirects => {
+      expect(sanitizeOptions({ security: { maxRedirects } }).security?.maxRedirects).toBe(
+        maxRedirects
+      );
+    });
+
+    test('should preserve valid boolean security options', () => {
+      expect(
+        sanitizeOptions({ security: { allowSvg: false, httpsOnly: true } }).security
+      ).toMatchObject({ allowSvg: false, httpsOnly: true });
+    });
+
+    test('should discard unknown runtime security keys', () => {
+      const sanitized = sanitizeOptions({
+        security: {
+          timeout: 1000,
+          padding: 'x'.repeat(20_000),
+        },
+      } as unknown as PreviewOptions);
+
+      expect(sanitized.security).toEqual({ timeout: 1000 });
+    });
+
+    test.each([null, [], 'unsafe', new Date()] as const)(
+      'should reject non-plain security options %# with VALIDATION_ERROR',
+      security => {
+        expect(() =>
+          sanitizeOptions({ security } as unknown as PreviewOptions)
+        ).toThrowError(/Security options must be a plain object/);
+      }
+    );
   });
 
   describe('createTransparentCanvas', () => {


### PR DESCRIPTION
## Summary
- validate JavaScript security option shapes before network work
- require booleans for allowSvg and httpsOnly and bound maxRedirects to integers from 0 through 10
- retain only documented security keys so unknown payloads cannot inflate request cache keys
- document the redirect bound and add unit/public-entrypoint regressions

## Verification
- pnpm exec vitest run test/unit/utils/validators.test.ts test/integration/end-to-end.test.ts (107 tests)
- pnpm run lint
- pnpm test (30 files, 549 tests)
- pnpm run build
- pnpm run verify:package
- git diff --check
- adversarial re-review: clean