### PR TITLE
fix(security): block non-global IPv6 special ranges

### DIFF
--- a/src/constants/security.ts
+++ b/src/constants/security.ts
@@ -28,6 +28,8 @@ export const BLOCKED_IP_RANGES = [
 /** Blocked IPv6 ranges */
 export const BLOCKED_IPV6_RANGES = [
   '::/96', // Deprecated IPv4-compatible addresses, including unspecified and loopback
+  '64:ff9b:1::/48', // Local-use IPv4-IPv6 translation (not globally reachable)
+  '5f00::/16', // Segment Routing (SRv6) SIDs (not globally reachable)
   'fc00::/7', // Unique Local
   'fe80::/10', // Link-local
   'fec0::/10', // Deprecated Site-local

--- a/test/unit/enhanced-secure-agent.test.ts
+++ b/test/unit/enhanced-secure-agent.test.ts
@@ -391,6 +391,8 @@ describe('Enhanced Secure Agent', () => {
         { hostname: 'link-local', address: 'fe80::1', family: 6 },         // Link-local
         { hostname: 'unique-local', address: 'fc00::1', family: 6 },       // Unique local
         { hostname: 'multicast', address: 'ff02::1', family: 6 },          // Multicast
+        { hostname: 'local-nat64', address: '64:ff9b:1::1', family: 6 },    // Local-use NAT64
+        { hostname: 'srv6-sid', address: '5f00::1', family: 6 },            // SRv6 SID
       ];
 
       for (const testCase of testCases) {
@@ -403,6 +405,49 @@ describe('Enhanced Secure Agent', () => {
         const result = await validateRequestSecurity(`https://${testCase.hostname}/test`);
         expect(result.allowed).toBe(false);
         
+        cleanup();
+      }
+    });
+
+    it.each([
+      ['socket-local-nat64', '64:ff9b:1::1'],
+      ['socket-srv6-sid', '5f00::1'],
+    ])('should reject %s at socket validation after DNS caching', async (hostname, address) => {
+      const cleanup = mockDNSLookup(hostname, [{ address, family: 6 }]);
+      const createConnectionSpy = vi.spyOn(http.Agent.prototype, 'createConnection');
+
+      try {
+        await useProductionIPClassifier();
+
+        // Rejected DNS results remain cached so socket validation can independently
+        // enforce the same destination policy against the actual peer address.
+        const result = await validateRequestSecurity(`http://${hostname}/`);
+        expect(result.allowed).toBe(false);
+
+        let connectListener: (() => void) | undefined;
+        const socketDestroy = vi.fn();
+        const mockSocket = {
+          remoteAddress: address,
+          remotePort: 80,
+          destroy: socketDestroy,
+          on: vi.fn((event: string, listener: () => void) => {
+            if (event === 'connect') connectListener = listener;
+          }),
+        } as unknown as net.Socket;
+
+        createConnectionSpy.mockImplementation(() => mockSocket);
+
+        const agent = createEnhancedSecureHttpAgent();
+        agent.createConnection({ host: hostname, port: 80 });
+        connectListener?.();
+
+        expect(socketDestroy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: `Connection rejected: socket IP validation failed for ${hostname}`,
+          })
+        );
+      } finally {
+        createConnectionSpy.mockRestore();
         cleanup();
       }
     });

--- a/test/unit/ip-validation.test.ts
+++ b/test/unit/ip-validation.test.ts
@@ -173,6 +173,22 @@ describe('IP Address Validation', () => {
       }
     );
 
+    it.each([
+      '64:ff9b:1::',
+      '64:ff9b:1:ffff:ffff:ffff:ffff:ffff',
+      '5f00::',
+      '5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+    ])('blocks non-globally-reachable special-purpose address %s', (address) => {
+      expect(isPrivateOrReservedIP(address)).toBe(true);
+    });
+
+    it.each(['64:ff9b::8.8.8.8', '2606:4700:4700::1111'])(
+      'does not over-block globally reachable address %s',
+      (address) => {
+        expect(isPrivateOrReservedIP(address)).toBe(false);
+      }
+    );
+
     it.each(['::192.168.1.1', '::8.8.8.8'])(
       'blocks deprecated IPv4-compatible address %s',
       (address) => {


### PR DESCRIPTION
## Summary
- block local-use NAT64 64:ff9b:1::/48 and SRv6 SID 5f00::/16 destinations
- enforce the same classification during direct checks, DNS validation, and socket revalidation
- preserve globally reachable NAT64 64:ff9b::/96 and ordinary global IPv6

IANA registry: https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml

## Verification
- focused IP/agent tests (2 files, 161 tests)
- pnpm run lint
- pnpm test (30 files, 557 tests)
- pnpm run build
- git diff --check
- adversarial review: clean