### PR TITLE
fix(network): support Node 26 lookup callbacks

### DIFF
--- a/src/utils/enhanced-secure-agent.ts
+++ b/src/utils/enhanced-secure-agent.ts
@@ -442,21 +442,43 @@ function validateIPAddresses(addresses: dns.LookupAddress[]): SecurityValidation
 /**
  * Enhanced secure DNS lookup with caching and comprehensive validation
  */
+type RuntimeLookupCallback = (
+  ...args:
+    | [NodeJS.ErrnoException | null, string, number]
+    | [NodeJS.ErrnoException | null, dns.LookupAddress[]]
+) => void;
+
 const enhancedSecureLookup: NonNullable<http.AgentOptions['lookup']> = (
   hostname,
   options,
   callback
 ): void => {
-  const returnAllAddresses = options.all === true;
+  const runtimeOptions = options as unknown as
+    | dns.LookupOneOptions
+    | dns.LookupAllOptions
+    | number
+    | RuntimeLookupCallback
+    | null
+    | undefined;
+  const actualCallback =
+    (typeof runtimeOptions === 'function'
+      ? runtimeOptions
+      : (callback as unknown as RuntimeLookupCallback | undefined)) ??
+    ((() => undefined) as RuntimeLookupCallback);
+  const normalizedOptions =
+    typeof runtimeOptions === 'object' && runtimeOptions !== null
+      ? runtimeOptions
+      : {};
+  const returnAllAddresses = normalizedOptions.all === true;
 
   const returnLookupError = (error: NodeJS.ErrnoException): void => {
     if (returnAllAddresses) {
-      callback(error, []);
+      actualCallback(error, []);
       return;
     }
 
     // Never return actual IPs in lookup errors - use placeholder values.
-    callback(error, '0.0.0.0', 4);
+    actualCallback(error, '0.0.0.0', 4);
   };
 
   // Use cached/fresh DNS lookup
@@ -485,7 +507,7 @@ const enhancedSecureLookup: NonNullable<http.AgentOptions['lookup']> = (
         // Node's autoSelectFamily path requests `all: true` and requires the
         // two-argument callback form. Return copies so consumers cannot mutate
         // the validated cache entries.
-        callback(
+        actualCallback(
           null,
           addresses.map(({ address, family }) => ({ address, family }))
         );
@@ -512,7 +534,7 @@ const enhancedSecureLookup: NonNullable<http.AgentOptions['lookup']> = (
         totalAddresses: addresses.length
       });
 
-      callback(null, firstSafeAddress.address, firstSafeAddress.family);
+      actualCallback(null, firstSafeAddress.address, firstSafeAddress.family);
     })
     .catch(err => {
       logger.error('DNS lookup failed', { hostname, error: err });

--- a/src/utils/enhanced-secure-agent.ts
+++ b/src/utils/enhanced-secure-agent.ts
@@ -442,27 +442,22 @@ function validateIPAddresses(addresses: dns.LookupAddress[]): SecurityValidation
 /**
  * Enhanced secure DNS lookup with caching and comprehensive validation
  */
-const enhancedSecureLookup = (
-  hostname: string,
-  options: dns.LookupOneOptions | dns.LookupAllOptions | number | undefined,
-  callback?: (err: NodeJS.ErrnoException | null, address: string, family: number) => void
+const enhancedSecureLookup: NonNullable<http.AgentOptions['lookup']> = (
+  hostname,
+  options,
+  callback
 ): void => {
-  // Normalize parameters
-  let actualCallback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+  const returnAllAddresses = options.all === true;
 
-  if (typeof options === 'function') {
-    actualCallback = options as unknown as (
-      err: NodeJS.ErrnoException | null,
-      address: string,
-      family: number
-    ) => void;
-  } else {
-    actualCallback = (callback || (() => {})) as (
-      err: NodeJS.ErrnoException | null,
-      address: string,
-      family: number
-    ) => void;
-  }
+  const returnLookupError = (error: NodeJS.ErrnoException): void => {
+    if (returnAllAddresses) {
+      callback(error, []);
+      return;
+    }
+
+    // Never return actual IPs in lookup errors - use placeholder values.
+    callback(error, '0.0.0.0', 4);
+  };
 
   // Use cached/fresh DNS lookup
   dnsCache.lookup(hostname)
@@ -483,8 +478,18 @@ const enhancedSecureLookup = (
           `Total resolved: ${addresses.length}, blocked: ${validation.blockedIPs.length}`
         );
 
-        // Never return actual IPs in security errors - use placeholder values
-        return actualCallback(securityError, '0.0.0.0', 4);
+        return returnLookupError(securityError);
+      }
+
+      if (returnAllAddresses) {
+        // Node's autoSelectFamily path requests `all: true` and requires the
+        // two-argument callback form. Return copies so consumers cannot mutate
+        // the validated cache entries.
+        callback(
+          null,
+          addresses.map(({ address, family }) => ({ address, family }))
+        );
+        return;
       }
 
       // Return first safe address - only from validated allowed IPs
@@ -497,7 +502,7 @@ const enhancedSecureLookup = (
         const criticalError = createNetworkPolicyError(
           `Critical security error: No safe addresses found for ${hostname}`
         );
-        return actualCallback(criticalError, '0.0.0.0', 4);
+        return returnLookupError(criticalError);
       }
 
       logger.debug('DNS lookup successful', {
@@ -507,11 +512,11 @@ const enhancedSecureLookup = (
         totalAddresses: addresses.length
       });
 
-      actualCallback(null, firstSafeAddress.address, firstSafeAddress.family);
+      callback(null, firstSafeAddress.address, firstSafeAddress.family);
     })
     .catch(err => {
       logger.error('DNS lookup failed', { hostname, error: err });
-      actualCallback(err as NodeJS.ErrnoException, '0.0.0.0', 4);
+      returnLookupError(err as NodeJS.ErrnoException);
     });
 };
 

--- a/test/unit/enhanced-secure-agent.test.ts
+++ b/test/unit/enhanced-secure-agent.test.ts
@@ -608,6 +608,54 @@ describe('Enhanced Secure Agent', () => {
       expect(mockIsPrivateOrReservedIP).toHaveBeenCalledTimes(2);
     });
 
+    it.each(['callback-only', 'undefined-options'] as const)(
+      'should preserve the legacy %s lookup invocation',
+      async invocation => {
+        const hostname = `lookup-${invocation}.example`;
+        const cleanup = mockDNSLookup(hostname, [{ address: '9.9.9.9', family: 4 }]);
+        cleanupFunctions.push(cleanup);
+        mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+        const agent = createEnhancedSecureHttpAgent();
+        const lookup = (
+          agent.options as { lookup: NonNullable<http.AgentOptions['lookup']> }
+        ).lookup as unknown as (
+          hostname: string,
+          optionsOrCallback:
+            | dns.LookupOneOptions
+            | ((error: NodeJS.ErrnoException | null, address: string, family: number) => void)
+            | undefined,
+          callback?: (
+            error: NodeJS.ErrnoException | null,
+            address: string,
+            family: number
+          ) => void
+        ) => void;
+
+        const result = await new Promise<dns.LookupAddress>((resolve, reject) => {
+          const callback = (
+            error: NodeJS.ErrnoException | null,
+            address: string,
+            family: number
+          ) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve({ address, family });
+          };
+
+          if (invocation === 'callback-only') {
+            lookup(hostname, callback);
+          } else {
+            lookup(hostname, undefined, callback);
+          }
+        });
+
+        expect(result).toEqual({ address: '9.9.9.9', family: 4 });
+      }
+    );
+
     it('should block the all lookup result when any resolved address is private', async () => {
       const cleanup = mockDNSLookup('lookup-all-mixed.example', [
         { address: '8.8.8.8', family: 4 },

--- a/test/unit/enhanced-secure-agent.test.ts
+++ b/test/unit/enhanced-secure-agent.test.ts
@@ -553,6 +553,87 @@ describe('Enhanced Secure Agent', () => {
       }
     });
 
+    it('should honor the all lookup callback contract used by autoSelectFamily', async () => {
+      const cleanup = mockDNSLookup('lookup-all.example', [
+        { address: '8.8.8.8', family: 4 },
+        { address: '2001:4860:4860::8888', family: 6 },
+      ]);
+      cleanupFunctions.push(cleanup);
+      mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+      const agent = createEnhancedSecureHttpAgent();
+      const lookup = (
+        agent.options as { lookup: NonNullable<http.AgentOptions['lookup']> }
+      ).lookup;
+      const addresses = await new Promise<dns.LookupAddress[]>((resolve, reject) => {
+        lookup('lookup-all.example', { all: true }, (error, resolvedAddresses) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(resolvedAddresses);
+        });
+      });
+
+      expect(addresses).toEqual([
+        { address: '8.8.8.8', family: 4 },
+        { address: '2001:4860:4860::8888', family: 6 },
+      ]);
+      expect(mockIsPrivateOrReservedIP).toHaveBeenCalledTimes(2);
+    });
+
+    it('should preserve the scalar lookup callback contract', async () => {
+      const cleanup = mockDNSLookup('lookup-one.example', [
+        { address: '8.8.4.4', family: 4 },
+        { address: '2001:4860:4860::8844', family: 6 },
+      ]);
+      cleanupFunctions.push(cleanup);
+      mockIsPrivateOrReservedIP.mockReturnValue(false);
+
+      const agent = createEnhancedSecureHttpAgent();
+      const lookup = (
+        agent.options as { lookup: NonNullable<http.AgentOptions['lookup']> }
+      ).lookup;
+      const result = await new Promise<dns.LookupAddress>((resolve, reject) => {
+        lookup('lookup-one.example', { all: false }, (error, address, family) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve({ address, family });
+        });
+      });
+
+      expect(result).toEqual({ address: '8.8.4.4', family: 4 });
+      expect(mockIsPrivateOrReservedIP).toHaveBeenCalledTimes(2);
+    });
+
+    it('should block the all lookup result when any resolved address is private', async () => {
+      const cleanup = mockDNSLookup('lookup-all-mixed.example', [
+        { address: '8.8.8.8', family: 4 },
+        { address: '192.168.1.20', family: 4 },
+      ]);
+      cleanupFunctions.push(cleanup);
+      mockIsPrivateOrReservedIP.mockImplementation(address => address === '192.168.1.20');
+
+      const agent = createEnhancedSecureHttpAgent();
+      const lookup = (
+        agent.options as { lookup: NonNullable<http.AgentOptions['lookup']> }
+      ).lookup;
+      const result = await new Promise<{
+        error: NodeJS.ErrnoException | null;
+        addresses: dns.LookupAddress[];
+      }>(resolve => {
+        lookup('lookup-all-mixed.example', { all: true }, (error, addresses) => {
+          resolve({ error, addresses });
+        });
+      });
+
+      expect(result.error).toMatchObject({ code: 'ECONNREFUSED' });
+      expect(result.addresses).toEqual([]);
+      expect(mockIsPrivateOrReservedIP).toHaveBeenCalledTimes(2);
+    });
+
     it('should create HTTP agent with security settings', () => {
       const agent = createEnhancedSecureHttpAgent();
       


### PR DESCRIPTION
## Summary
- honor the DNS lookup all:true callback shape used by Node 26 autoSelectFamily
- return cloned validated address arrays for all-form lookups while preserving scalar behavior
- preserve callback-only, undefined-options, numeric/null, and missing-callback invocation compatibility
- fail closed when any resolved address is private or reserved
- preserve existing DNS cache, admission, timeout, abort, policy-error, and socket-budget behavior

Node docs: https://nodejs.org/api/dns.html and https://nodejs.org/api/net.html

## Verification
- pre-fix Node 26 real request: ERR_INVALID_IP_ADDRESS
- legacy overload regressions failed before fix and now pass
- Node 22.22.1: 30 files, 577 tests
- Node 24.18.0: 30 files, 577 tests
- Node 26.5.0: focused 47 tests and full 577 tests
- Node 26 real enhanced HTTPS request after final fix: status 200
- pnpm run lint
- pnpm run build
- git diff --check
- adversarial re-review: clean