### PR TITLE
feat!: remove unsupported fallback options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ interface PreviewOptions {
   quality?: number; // JPEG quality 1-100 (default: 90)
   cache?: boolean; // Cache generated results in memory (default: false)
   fallback?: {
-    strategy?: 'auto' | 'custom' | 'generate'; // Fallback strategy
-    image?: string; // Custom fallback image path
+    strategy?: 'auto' | 'generate'; // Fallback strategy
     text?: string; // Custom fallback text
   };
   colors?: {

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -113,6 +113,37 @@ function verifyRuntimeExports(packageExports) {
   }
 }
 
+async function verifyRemovedFallbackRuntimeInputs(packageExports) {
+  const removedInputs = [
+    ['fallback.strategy=custom', { strategy: 'custom' }],
+    ['fallback.image', { image: undefined }],
+    ['fallback.category', { category: 'tech' }],
+    ['fallback.backgroundColor', { backgroundColor: '#000000' }],
+  ];
+
+  for (const [description, fallback] of removedInputs) {
+    let rejection;
+    try {
+      await packageExports.generatePreviewFromMetadata(
+        {
+          title: 'Removed fallback runtime smoke',
+          url: 'https://example.com/removed-fallback-smoke',
+        },
+        { fallback }
+      );
+    } catch (error) {
+      rejection = error;
+    }
+
+    if (!(rejection instanceof packageExports.PreviewGeneratorError)) {
+      throw new Error(`Packed package did not reject ${description} with PreviewGeneratorError`);
+    }
+    if (rejection.type !== packageExports.ErrorType.VALIDATION_ERROR) {
+      throw new Error(`Packed package did not reject ${description} with VALIDATION_ERROR`);
+    }
+  }
+}
+
 function verifyEsmImport() {
   const esmCheck = `
     const packageExports = await import(${JSON.stringify(PACKAGE_NAME)});
@@ -155,6 +186,14 @@ function verifyTypeScriptConsumer() {
         url: 'https://example.com/typescript-smoke',
       };
       const options: PreviewOptions = { width: 320, height: 168, template: 'minimal' };
+      // @ts-expect-error fallback.strategy custom was removed in 0.3.0
+      const removedCustomStrategy: PreviewOptions = { fallback: { strategy: 'custom' } };
+      // @ts-expect-error fallback.image was removed in 0.3.0
+      const removedFallbackImage: PreviewOptions = { fallback: { image: 'fallback.png' } };
+      // @ts-expect-error fallback.category was removed in 0.3.0
+      const removedFallbackCategory: PreviewOptions = { fallback: { category: 'tech' } };
+      // @ts-expect-error fallback.backgroundColor was removed in 0.3.0
+      const removedFallbackBackground: PreviewOptions = { fallback: { backgroundColor: '#000000' } };
       const extracted: ExtractedMetadata = metadata;
       const template: TemplateConfig = {
         name: 'consumer-smoke',
@@ -172,6 +211,10 @@ function verifyTypeScriptConsumer() {
       void detailed;
       void custom;
       void typedError;
+      void removedCustomStrategy;
+      void removedFallbackImage;
+      void removedFallbackCategory;
+      void removedFallbackBackground;
     `
   );
   writeFileSync(
@@ -243,6 +286,7 @@ try {
   packageExports = requireFromConsumer(PACKAGE_NAME);
   verifyRuntimeExports(packageExports);
   verifyEsmImport();
+  await verifyRemovedFallbackRuntimeInputs(packageExports);
 
   const image = await packageExports.generatePreviewFromMetadata(
     {
@@ -271,7 +315,7 @@ try {
   }
 
   console.log(
-    'Packed package passed tarball, CJS/ESM import, runtime export, 320x168 JPEG, and TypeScript consumer checks.'
+    'Packed package passed tarball, CJS/ESM import, runtime export, removed fallback, 320x168 JPEG, and TypeScript consumer checks.'
   );
   if (outputPath) {
     console.log(`Verified tarball written to ${outputPath}.`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,15 +103,9 @@ export type TemplateType = 'modern' | 'classic' | 'minimal';
  */
 export interface FallbackOptions {
   /** Strategy for handling missing data */
-  strategy?: 'auto' | 'custom' | 'generate';
-  /** Path to custom fallback image */
-  image?: string;
-  /** Category for auto-selecting fallback images */
-  category?: 'tech' | 'business' | 'lifestyle' | 'news' | 'general';
+  strategy?: 'auto' | 'generate';
   /** Custom text to use when generating fallback */
   text?: string;
-  /** Background color for generated fallback */
-  backgroundColor?: string;
 }
 
 /**

--- a/src/utils/validators/options.ts
+++ b/src/utils/validators/options.ts
@@ -46,7 +46,34 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
   if (options.colors) {
     sanitized.colors = { ...options.colors };
   }
+  if (options.fallback !== undefined && !isPlainObject(options.fallback)) {
+    throw new PreviewGeneratorError(
+      ErrorType.VALIDATION_ERROR,
+      'Fallback options must be a plain object'
+    );
+  }
   if (options.fallback) {
+    const fallback = options.fallback as Record<string, unknown>;
+    for (const field of ['image', 'category', 'backgroundColor'] as const) {
+      if (Object.hasOwn(fallback, field)) {
+        throw new PreviewGeneratorError(
+          ErrorType.VALIDATION_ERROR,
+          `Removed fallback option is not supported: fallback.${field}`
+        );
+      }
+    }
+
+    if (
+      fallback.strategy !== undefined &&
+      fallback.strategy !== 'auto' &&
+      fallback.strategy !== 'generate'
+    ) {
+      throw new PreviewGeneratorError(
+        ErrorType.VALIDATION_ERROR,
+        `Fallback strategy must be "auto" or "generate", got: ${String(fallback.strategy)}`
+      );
+    }
+
     sanitized.fallback = { ...options.fallback };
   }
   if (options.security !== undefined && !isPlainObject(options.security)) {

--- a/src/utils/validators/options.ts
+++ b/src/utils/validators/options.ts
@@ -74,7 +74,13 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
       );
     }
 
-    sanitized.fallback = { ...options.fallback };
+    const knownFallback: Record<string, unknown> = {};
+    for (const field of ['strategy', 'text'] as const) {
+      if (Object.hasOwn(fallback, field)) {
+        knownFallback[field] = fallback[field];
+      }
+    }
+    sanitized.fallback = knownFallback as PreviewOptions['fallback'];
   }
   if (options.security !== undefined && !isPlainObject(options.security)) {
     throw new PreviewGeneratorError(

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -245,6 +245,21 @@ describe('Validators', () => {
       }
     );
 
+    test('should discard unknown runtime fallback keys', () => {
+      const sanitized = sanitizeOptions({
+        fallback: {
+          strategy: 'generate',
+          text: '  fallback text  ',
+          padding: 'x'.repeat(20_000),
+        },
+      } as unknown as PreviewOptions);
+
+      expect(sanitized.fallback).toEqual({
+        strategy: 'generate',
+        text: 'fallback text',
+      });
+    });
+
     test('should reject invalid font option shapes with validation errors', () => {
       expect(() =>
         sanitizeOptions({

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -196,6 +196,55 @@ describe('Validators', () => {
       expect(sanitized.fonts?.[0]).not.toBe(originalFonts?.[0]);
     });
 
+    test.each(['auto', 'generate'] as const)(
+      'should preserve the supported fallback strategy %s',
+      strategy => {
+        expect(sanitizeOptions({ fallback: { strategy } }).fallback?.strategy).toBe(strategy);
+      }
+    );
+
+    test('should reject the removed custom fallback strategy with VALIDATION_ERROR', () => {
+      try {
+        sanitizeOptions({
+          fallback: { strategy: 'custom' },
+        } as unknown as PreviewOptions);
+        throw new Error('Expected sanitizeOptions to reject fallback.strategy');
+      } catch (error) {
+        expect(error).toBeInstanceOf(PreviewGeneratorError);
+        expect((error as PreviewGeneratorError).type).toBe(ErrorType.VALIDATION_ERROR);
+        expect((error as PreviewGeneratorError).message).toContain('Fallback strategy');
+      }
+    });
+
+    test.each([
+      ['image', 'fallback.png'],
+      ['category', 'tech'],
+      ['backgroundColor', undefined],
+    ] as const)(
+      'should reject the removed fallback option %s with VALIDATION_ERROR',
+      (field, value) => {
+        try {
+          sanitizeOptions({
+            fallback: { [field]: value },
+          } as unknown as PreviewOptions);
+          throw new Error(`Expected sanitizeOptions to reject fallback.${field}`);
+        } catch (error) {
+          expect(error).toBeInstanceOf(PreviewGeneratorError);
+          expect((error as PreviewGeneratorError).type).toBe(ErrorType.VALIDATION_ERROR);
+          expect((error as PreviewGeneratorError).message).toContain(`fallback.${field}`);
+        }
+      }
+    );
+
+    test.each([null, [], 'generate', new Date()] as const)(
+      'should reject non-plain fallback options %# with VALIDATION_ERROR',
+      fallback => {
+        expect(() =>
+          sanitizeOptions({ fallback } as unknown as PreviewOptions)
+        ).toThrowError(/Fallback options must be a plain object/);
+      }
+    );
+
     test('should reject invalid font option shapes with validation errors', () => {
       expect(() =>
         sanitizeOptions({


### PR DESCRIPTION
## Summary

- remove the unimplemented `fallback.strategy: 'custom'` contract and dead `image`, `category`, and `backgroundColor` fields
- reject those legacy JavaScript inputs with `VALIDATION_ERROR`, including own properties set to `undefined`
- align the README and packed-package runtime/TypeScript consumer checks with the supported `auto` and `generate` strategies

## Breaking change

This intentionally narrows `PreviewOptions.fallback` for the upcoming 0.3.0 release. `fonts` and `colors.primary`/`colors.secondary` remain unchanged. The version bump will follow in a separate release PR after this change merges.

## Validation

- `pnpm exec vitest run test/unit/utils/validators.test.ts` (73 passed)
- `pnpm run lint`
- `pnpm run build`
- `SKIP_NETWORK_TESTS=true pnpm test` (587 passed)
- `pnpm audit --prod --audit-level=high` (0 vulnerabilities)
- `pnpm run verify:release -- --tag v0.2.6`
- `pnpm run verify:package -- --output /private/tmp/social-preview-cleanup-package.tgz`
- `git diff --check`
