### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanggo/social-preview",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Generate beautiful social media preview images from any URL",
   "packageManager": "pnpm@10.11.0",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump `@nanggo/social-preview` from 0.2.6 to 0.3.0
- release the breaking fallback API cleanup merged in #74
- keep the lockfile unchanged because this pnpm workspace lockfile has no root package version field

After this PR merges cleanly, an annotated `v0.3.0` tag will trigger the trusted-publishing workflow.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `SKIP_NETWORK_TESTS=true pnpm test` (588 passed)
- `pnpm audit --prod --audit-level=high` (0 vulnerabilities)
- `pnpm run verify:release -- --tag v0.3.0`
- `pnpm run verify:package -- --output /private/tmp/social-preview-0.3.0.tgz`
- npm registry check: latest is 0.2.6 and 0.3.0 is not published
- `git diff --check`
