### PR TITLE
feat: add article preview template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Social Preview Generator
 
+**English** | [한국어](https://github.com/nanggo/social-preview-generator/blob/master/docs/README.ko.md)
+
 Generate Open Graph/social preview images from URLs or known page metadata.
 
 [![npm version](https://img.shields.io/npm/v/@nanggo/social-preview.svg)](https://www.npmjs.com/package/@nanggo/social-preview)
@@ -10,7 +12,7 @@ Generate Open Graph/social preview images from URLs or known page metadata.
 
 - Extract Open Graph and Twitter Card metadata from a URL
 - Generate images directly from supplied metadata for static publishing flows
-- Render with built-in `modern`, `classic`, and `minimal` templates
+- Render with built-in `modern`, `classic`, `minimal`, and `article` templates
 - Process and optimize images with Sharp
 - Fall back to generated previews when metadata is incomplete
 - Ship TypeScript definitions
@@ -69,16 +71,18 @@ canonical URL, and cover image are known at publish/build time.
 
 ```typescript
 interface PreviewOptions {
-  template?: 'modern' | 'classic' | 'minimal'; // Template to use (default: 'modern')
+  template?: 'modern' | 'classic' | 'minimal' | 'article'; // Template to use (default: 'modern')
   width?: number; // Image width (default: 1200)
   height?: number; // Image height (default: 630)
   quality?: number; // JPEG quality 1-100 (default: 90)
   cache?: boolean; // Cache generated results in memory (default: false)
+  mobilePreview?: boolean; // Article only; defaults to true when a description exists
   fallback?: {
     strategy?: 'auto' | 'generate'; // Fallback strategy
     text?: string; // Custom fallback text
   };
   colors?: {
+    primary?: string; // Article primary color (default: '#3182F6')
     background?: string; // Background color
     text?: string; // Text color
     accent?: string; // Accent color
@@ -151,6 +155,23 @@ const buffer = await generatePreview('https://example.com', {
 });
 ```
 
+### Article Preview
+
+Use `mobilePreview: false` for a text-only article card. When omitted, the article template shows
+the mobile preview whenever the metadata includes a description. Near-square and portrait outputs
+stack the mobile surface below the title automatically. The layout targets standard social-preview
+aspect ratios; extreme aspect ratios are rendered on a best-effort basis.
+
+```javascript
+const buffer = await generatePreviewFromMetadata(metadata, {
+  template: 'article',
+  mobilePreview: true,
+  colors: {
+    primary: '#7C3AED',
+  },
+});
+```
+
 ## Templates
 
 ### Modern (Default)
@@ -172,6 +193,14 @@ const buffer = await generatePreview('https://example.com', {
 - Minimal decorations
 - Ideal for documentation sites
 
+### Article
+
+- Editorial layout for article and blog metadata
+- Optional mobile preview, enabled by default when a description exists
+- Responsive stacked layout for near-square and portrait output sizes
+- Customizable primary color through `colors.primary` (default: `#3182F6`)
+- Metadata-only rendering; remote cover images are intentionally not used
+
 ## Architecture
 
 ```
@@ -186,6 +215,7 @@ social-preview-generator/
 │   │   ├── modern.ts                    # Modern template
 │   │   ├── classic.ts                   # Classic template
 │   │   ├── minimal.ts                   # Minimal template
+│   │   ├── article.ts                   # Article template
 │   │   ├── shared.ts                    # Shared layout helpers
 │   │   └── registry.ts                  # Template registry
 │   ├── utils/                           # Shared utilities & security

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,0 +1,256 @@
+# Social Preview Generator
+
+[English](../README.md) | **한국어**
+
+URL 또는 이미 알고 있는 페이지 메타데이터로 Open Graph 및 소셜 미리보기 이미지를 생성합니다.
+
+[![npm version](https://img.shields.io/npm/v/@nanggo/social-preview.svg)](https://www.npmjs.com/package/@nanggo/social-preview)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js CI](https://github.com/nanggo/social-preview-generator/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/nanggo/social-preview-generator/actions/workflows/npm-publish.yml)
+
+## 주요 기능
+
+- URL에서 Open Graph 및 Twitter Card 메타데이터 추출
+- 정적 게시 흐름에서 전달받은 메타데이터로 이미지 직접 생성
+- 내장된 `modern`, `classic`, `minimal`, `article` 템플릿으로 렌더링
+- Sharp를 사용한 이미지 처리 및 최적화
+- 메타데이터가 불완전할 때 생성형 미리보기로 대체
+- TypeScript 타입 정의 제공
+- 한국어 텍스트 렌더링 지원
+
+## 설치
+
+Node.js 22.13 이상(22.x) 또는 24 이상이 필요합니다.
+
+```bash
+npm install @nanggo/social-preview
+```
+
+## 빠른 시작
+
+```javascript
+const { generatePreview } = require('@nanggo/social-preview');
+
+const imageBuffer = await generatePreview('https://github.com');
+
+const fs = require('fs').promises;
+await fs.writeFile('preview.jpg', imageBuffer);
+```
+
+## API
+
+### `generatePreview(url, options?)`
+
+URL로 소셜 미리보기 이미지를 생성합니다.
+
+#### 매개변수
+
+- `url` (string): 미리보기를 생성할 URL
+- `options` (PreviewOptions): 선택적 설정
+
+#### 반환값
+
+- `Promise<Buffer>`: JPEG 형식의 이미지 버퍼
+
+### `generatePreviewFromMetadata(metadata, options?)`
+
+이미 가지고 있는 메타데이터로 소셜 미리보기 이미지를 생성합니다. 페이지 URL을 가져오거나
+스크래핑하지 않으므로 제목, 설명, 정규 URL, 커버 이미지를 게시 또는 빌드 시점에 알고 있는
+정적 블로그 게시 파이프라인에 유용합니다.
+
+#### 매개변수
+
+- `metadata` (PreviewMetadataInput): 렌더링할 페이지 또는 게시물 메타데이터
+- `options` (PreviewOptions): 선택적 설정
+
+#### 반환값
+
+- `Promise<Buffer>`: JPEG 형식의 이미지 버퍼
+
+### 옵션
+
+```typescript
+interface PreviewOptions {
+  template?: 'modern' | 'classic' | 'minimal' | 'article'; // 사용할 템플릿(기본값: 'modern')
+  width?: number; // 이미지 너비(기본값: 1200)
+  height?: number; // 이미지 높이(기본값: 630)
+  quality?: number; // JPEG 품질 1-100(기본값: 90)
+  cache?: boolean; // 생성 결과를 메모리에 캐시(기본값: false)
+  mobilePreview?: boolean; // article 전용. 설명이 있으면 기본값은 true
+  fallback?: {
+    strategy?: 'auto' | 'generate'; // 대체 전략
+    text?: string; // 사용자 지정 대체 텍스트
+  };
+  colors?: {
+    primary?: string; // article 주 색상(기본값: '#3182F6')
+    background?: string; // 배경색
+    text?: string; // 텍스트 색상
+    accent?: string; // 강조색
+  };
+}
+```
+
+### 정적 블로그 게시
+
+게시물을 발행할 때 이미지를 한 번 생성한 다음, 저장한 파일을 `og:image`로 지정합니다.
+
+```javascript
+const { generatePreviewFromMetadata } = require('@nanggo/social-preview');
+const fs = require('fs').promises;
+
+const buffer = await generatePreviewFromMetadata(
+  {
+    title: 'How to Generate Open Graph Images',
+    description: 'Create a social preview image while publishing a blog post.',
+    siteName: 'My Blog',
+    url: 'https://example.com/posts/open-graph-images',
+    image: 'https://example.com/images/open-graph-cover.jpg',
+  },
+  {
+    template: 'modern',
+    width: 1200,
+    height: 630,
+    quality: 90,
+  }
+);
+
+await fs.writeFile('public/og/open-graph-images.jpg', buffer);
+```
+
+## 예제
+
+### 기본 사용법
+
+```javascript
+const { generatePreview } = require('@nanggo/social-preview');
+
+async function createPreview() {
+  const buffer = await generatePreview('https://www.npmjs.com');
+  await fs.writeFile('npm-preview.jpg', buffer);
+}
+```
+
+### 스타일 사용자 지정
+
+```javascript
+const buffer = await generatePreview('https://example.com', {
+  template: 'modern',
+  colors: {
+    background: '#2c3e50',
+    accent: '#3498db',
+    text: '#ffffff',
+  },
+  quality: 95,
+});
+```
+
+### 대체 처리
+
+```javascript
+const buffer = await generatePreview('https://example.com', {
+  fallback: {
+    strategy: 'generate',
+    text: 'My Custom Preview',
+  },
+});
+```
+
+### 아티클 미리보기
+
+텍스트만 있는 아티클 카드에는 `mobilePreview: false`를 사용합니다. 옵션을 생략하면 메타데이터에
+설명이 있을 때 `article` 템플릿이 모바일 미리보기를 표시합니다. 정사각형에 가까운 비율과
+세로형 출력에서는 모바일 화면이 제목 아래에 자동으로 배치됩니다. 일반적인 소셜 미리보기
+비율을 기준으로 하며, 극단적인 화면 비율은 가능한 범위에서만 대응합니다.
+
+```javascript
+const buffer = await generatePreviewFromMetadata(metadata, {
+  template: 'article',
+  mobilePreview: true,
+  colors: {
+    primary: '#7C3AED',
+  },
+});
+```
+
+## 템플릿
+
+### Modern (기본값)
+
+- 깔끔하고 현대적인 디자인
+- 그라디언트 오버레이
+- 중앙 정렬 텍스트 레이아웃
+- 기술 및 현대적인 웹사이트에 적합
+
+### Classic
+
+- 전통적인 카드 레이아웃
+- 위쪽에 이미지, 아래쪽에 텍스트 배치
+- 뉴스 및 블로그 사이트에 적합
+
+### Minimal
+
+- 단순하고 텍스트 중심적인 디자인
+- 최소한의 장식
+- 문서 사이트에 적합
+
+### Article
+
+- 아티클 및 블로그 메타데이터를 위한 편집 디자인 레이아웃
+- 설명이 있으면 기본으로 활성화되는 선택적 모바일 미리보기
+- 정사각형에 가까운 비율과 세로형 출력에 대응하는 반응형 스택 레이아웃
+- `colors.primary`로 주 색상 사용자 지정 가능(기본값: `#3182F6`)
+- 메타데이터만 사용해 렌더링하며, 원격 커버 이미지는 의도적으로 사용하지 않음
+
+## 아키텍처
+
+```
+social-preview-generator/
+├── src/
+│   ├── core/
+│   │   ├── metadata-extractor.ts        # URL 메타데이터 추출
+│   │   ├── image-generator.ts           # 이미지 생성 엔진
+│   │   ├── overlay-generator.ts         # SVG 텍스트 오버레이 생성
+│   │   └── template-image-processing.ts # 템플릿별 이미지 처리
+│   ├── templates/
+│   │   ├── modern.ts                    # Modern 템플릿
+│   │   ├── classic.ts                   # Classic 템플릿
+│   │   ├── minimal.ts                   # Minimal 템플릿
+│   │   ├── article.ts                   # Article 템플릿
+│   │   ├── shared.ts                    # 공유 레이아웃 도우미
+│   │   └── registry.ts                  # 템플릿 레지스트리
+│   ├── utils/                           # 공유 유틸리티 및 보안
+│   ├── constants/                       # 보안 제한 및 글꼴 설정
+│   ├── types/
+│   │   └── index.ts                     # TypeScript 타입 정의
+│   └── index.ts                         # 메인 진입점
+```
+
+## 기여하기
+
+기여를 환영합니다! 언제든지 Pull Request를 보내 주세요.
+
+1. 저장소를 포크합니다.
+2. 기능 브랜치를 생성합니다(`git checkout -b feature/amazing-feature`).
+3. 변경 사항을 커밋합니다(`git commit -m 'Add some amazing feature'`).
+4. 브랜치에 푸시합니다(`git push origin feature/amazing-feature`).
+5. Pull Request를 엽니다.
+
+## 라이선스
+
+이 프로젝트는 MIT 라이선스를 따릅니다. 자세한 내용은 [LICENSE](../LICENSE) 파일을 참고하세요.
+
+## 감사의 말
+
+- [Sharp](https://sharp.pixelplumbing.com/) - 고성능 이미지 처리
+- [Open Graph Scraper](https://github.com/jshemas/openGraphScraper) - 메타데이터 추출
+- [Axios](https://axios-http.com/) - HTTP 클라이언트
+
+## 링크
+
+- [npm 패키지](https://www.npmjs.com/package/@nanggo/social-preview)
+- [GitHub 저장소](https://github.com/nanggo/social-preview-generator)
+- [이슈 제보](https://github.com/nanggo/social-preview-generator/issues)
+
+---
+
+[nanggo](https://github.com/nanggo)가 만들었습니다.

--- a/scripts/verify-packed-package.mjs
+++ b/scripts/verify-packed-package.mjs
@@ -183,9 +183,16 @@ function verifyTypeScriptConsumer() {
 
       const metadata: PreviewMetadataInput = {
         title: 'TypeScript package smoke',
+        description: 'Article summary rendered inside the mobile preview.',
         url: 'https://example.com/typescript-smoke',
       };
-      const options: PreviewOptions = { width: 320, height: 168, template: 'minimal' };
+      const options: PreviewOptions = {
+        width: 320,
+        height: 168,
+        template: 'article',
+        mobilePreview: true,
+        colors: { primary: '#3182F6' },
+      };
       // @ts-expect-error fallback.strategy custom was removed in 0.3.0
       const removedCustomStrategy: PreviewOptions = { fallback: { strategy: 'custom' } };
       // @ts-expect-error fallback.image was removed in 0.3.0
@@ -291,9 +298,17 @@ try {
   const image = await packageExports.generatePreviewFromMetadata(
     {
       title: 'Packed package render smoke',
+      description: 'Article summary rendered inside the packed package smoke test.',
       url: 'https://example.com/package-smoke',
     },
-    { cache: false, height: 168, template: 'minimal', width: 320 }
+    {
+      cache: false,
+      colors: { primary: '#3182F6' },
+      height: 168,
+      mobilePreview: true,
+      template: 'article',
+      width: 320,
+    }
   );
   const sharp = requireFromConsumer('sharp');
   const imageMetadata = await sharp(image).metadata();
@@ -315,7 +330,7 @@ try {
   }
 
   console.log(
-    'Packed package passed tarball, CJS/ESM import, runtime export, removed fallback, 320x168 JPEG, and TypeScript consumer checks.'
+    'Packed package passed tarball, CJS/ESM import, runtime export, removed fallback, article 320x168 JPEG, and TypeScript consumer checks.'
   );
   if (outputPath) {
     console.log(`Verified tarball written to ${outputPath}.`);

--- a/src/constants/security.ts
+++ b/src/constants/security.ts
@@ -356,7 +356,7 @@ export const QUALITY_LIMITS = {
 } as const;
 
 /** Template validation */
-export const ALLOWED_TEMPLATES = ['modern', 'classic', 'minimal'] as const;
+export const ALLOWED_TEMPLATES = ['modern', 'classic', 'minimal', 'article'] as const;
 
 // =============================================================================
 // SECURITY EXPORT

--- a/src/templates/article.ts
+++ b/src/templates/article.ts
@@ -323,6 +323,16 @@ function wrapArticleText(
     }
 
     cursor = nextStart > cursor ? nextStart : cursor + 1;
+
+    if (maxLines >= 1 && lines.length === maxLines && cursor < source.length) {
+      lines[maxLines - 1] = appendEllipsis(
+        lines[maxLines - 1],
+        maxWidth,
+        fontSize,
+        letterSpacingEm
+      );
+      return lines;
+    }
   }
   if (lines.length <= maxLines) {
     return lines;

--- a/src/templates/article.ts
+++ b/src/templates/article.ts
@@ -1,0 +1,907 @@
+/**
+ * Article Template
+ * A metadata-first editorial preview with an optional mobile summary surface.
+ */
+
+import { SYSTEM_FONT_STACK } from '../constants/fonts';
+import type { ExtractedMetadata, PreviewOptions, TemplateConfig } from '../types';
+import { escapeXml } from '../utils';
+import { validateColor } from '../utils/validators';
+import { createSvgStyleCdata, layoutCenteredTitleDescription } from './shared';
+
+const BASE_WIDTH = 1200;
+const BASE_HEIGHT = 630;
+const DEFAULT_PRIMARY = '#3182F6';
+const DEFAULT_BACKGROUND = '#F2F4F6';
+const DEFAULT_TEXT = '#191F28';
+const DEFAULT_SECONDARY = '#4E5968';
+const STACKED_LAYOUT_WIDTH = 1200;
+const STACKED_LAYOUT_MAX_ASPECT_RATIO = 1.4;
+
+const PROHIBITED_LINE_START =
+  /^[\u0021\u0029\u002C\u002E\u003A\u003B\u003F\u005D\u007D\u3001\u3002\uFF0C\uFF0E\u30FB\uFF1A\uFF1B\uFF1F\uFF01\u309B\u309C\u30FD\u30FE\u309D\u309E\u3005\u303B\u30FC\u2010\u2013\u2019\u201D\u2025\u2026\u203C\u2047-\u2049\u3009\u300B\u300D\u300F\u3011\u3015\u3017\u3019\u301B\u301E\u301F\uFF09\uFF3D\uFF5D\uFF60\uFF61\uFF63\uFF64\uFF67-\uFF70\u00BB\u3041\u3043\u3045\u3047\u3049\u3063\u3083\u3085\u3087\u308E\u30A1\u30A3\u30A5\u30A7\u30A9\u30C3\u30E3\u30E5\u30E7\u30EE\u30F5\u30F6]/u;
+const PROHIBITED_LINE_END =
+  /^[\u3008\u300A\u300C\u300E\u3010\u3014\u3016\u3018\u301A\u301D\uFF08\uFF3B\uFF5B\uFF5F\uFF62\u00AB\u0028\u005B\u007B\u2018\u201C]/u;
+
+const graphemeSegmenter = new Intl.Segmenter('ko', { granularity: 'grapheme' });
+
+interface TextBlockOptions {
+  lines: string[];
+  x: number;
+  firstBaseline: number;
+  fontSize: number;
+  lineHeight: number;
+  className: string;
+  anchor?: 'start' | 'middle' | 'end';
+}
+
+interface ArticleViewport {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface MobilePanelLayout {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale: number;
+  stacked: boolean;
+}
+
+/**
+ * Article template configuration.
+ *
+ * The template intentionally ignores remote article imagery. It reconstructs a
+ * compact reading surface from metadata so generation stays deterministic and
+ * does not require a browser or screenshot dependency.
+ */
+export const articleTemplate: TemplateConfig = {
+  name: 'article',
+  layout: {
+    padding: 80,
+    titlePosition: 'left',
+    descriptionPosition: 'below-title',
+    imagePosition: 'none',
+    logoPosition: 'bottom-left',
+  },
+  typography: {
+    title: {
+      fontSize: 68,
+      fontWeight: '800',
+      lineHeight: 1.12,
+      maxLines: 3,
+    },
+    description: {
+      fontSize: 28,
+      fontWeight: '400',
+      lineHeight: 1.45,
+      maxLines: 3,
+    },
+    siteName: {
+      fontSize: 20,
+      fontWeight: '700',
+    },
+  },
+  effects: {
+    shadow: {
+      text: false,
+      box: true,
+    },
+    borderRadius: 34,
+  },
+  imageProcessing: {
+    requiresTransparentCanvas: true,
+  },
+  overlayGenerator: generateArticleOverlay,
+};
+
+function estimateGraphemeWidth(grapheme: string, fontSize: number): number {
+  if (/^\s$/u.test(grapheme)) {
+    return fontSize * 0.32;
+  }
+
+  if (
+    /\p{Extended_Pictographic}/u.test(grapheme) ||
+    /\p{Regional_Indicator}/u.test(grapheme) ||
+    /\u20E3/u.test(grapheme) ||
+    /[\u3000-\u303F\u3200-\u33FF\uFE10-\uFE6F\uFF01-\uFF60\uFFE0-\uFFE6]/u.test(grapheme) ||
+    /\p{Script=Han}|\p{Script=Hangul}|\p{Script=Hiragana}|\p{Script=Katakana}/u.test(grapheme)
+  ) {
+    return fontSize;
+  }
+
+  const decomposedBase = grapheme.normalize('NFD').replace(/\p{M}/gu, '');
+
+  if (/^[MW]$/u.test(decomposedBase)) {
+    return fontSize;
+  }
+
+  if (/^[A-Z]$/u.test(decomposedBase)) {
+    return fontSize * 0.7;
+  }
+
+  if (/^[0-9]$/u.test(decomposedBase)) {
+    return fontSize * 0.62;
+  }
+
+  if (/^[mw]$/u.test(decomposedBase)) {
+    return fontSize * 0.85;
+  }
+
+  if (/^[il]$/u.test(decomposedBase)) {
+    return fontSize * 0.25;
+  }
+
+  if (/^[fjrt]$/u.test(decomposedBase)) {
+    return fontSize * 0.4;
+  }
+
+  if (/^[a-z]$/u.test(decomposedBase)) {
+    return fontSize * 0.53;
+  }
+
+  if (/^[—…]$/u.test(grapheme) || /[\p{L}\p{N}\p{M}]/u.test(grapheme)) {
+    return fontSize;
+  }
+
+  if (/^[.,:;'"`!]$/u.test(grapheme)) {
+    return fontSize * 0.23;
+  }
+
+  if (/^[?\-_/\\|()[\]{}<>]$/u.test(grapheme)) {
+    return fontSize * 0.55;
+  }
+
+  if (/^[@%#&]$/u.test(grapheme)) {
+    return fontSize * 0.9;
+  }
+
+  if (/^[*+=$^~]$/u.test(grapheme)) {
+    return fontSize * 0.7;
+  }
+
+  if (/^[\p{P}\p{S}]$/u.test(grapheme)) {
+    return fontSize;
+  }
+
+  return fontSize;
+}
+
+function measureGraphemes(graphemes: string[], fontSize: number, letterSpacingEm = 0): number {
+  const glyphWidth = graphemes.reduce(
+    (total, grapheme) => total + estimateGraphemeWidth(grapheme, fontSize),
+    0
+  );
+  const spacingWidth = Math.max(0, graphemes.length - 1) * fontSize * letterSpacingEm;
+
+  return glyphWidth + spacingWidth;
+}
+
+function trimGraphemeWhitespace(graphemes: string[]): string[] {
+  let start = 0;
+  let end = graphemes.length;
+
+  while (start < end && /^\s$/u.test(graphemes[start])) {
+    start += 1;
+  }
+  while (end > start && /^\s$/u.test(graphemes[end - 1])) {
+    end -= 1;
+  }
+
+  return graphemes.slice(start, end);
+}
+
+function findLastWhitespace(graphemes: string[]): number {
+  for (let index = graphemes.length - 1; index >= 0; index -= 1) {
+    if (/^\s$/u.test(graphemes[index])) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function appendEllipsis(
+  line: string,
+  maxWidth: number,
+  fontSize: number,
+  letterSpacingEm: number
+): string {
+  const ellipsis = '…';
+  const graphemes = Array.from(graphemeSegmenter.segment(line), (part) => part.segment);
+
+  while (
+    graphemes.length > 0 &&
+    measureGraphemes([...graphemes, ellipsis], fontSize, letterSpacingEm) > maxWidth
+  ) {
+    graphemes.pop();
+  }
+
+  while (graphemes.length > 0 && PROHIBITED_LINE_END.test(graphemes[graphemes.length - 1])) {
+    graphemes.pop();
+  }
+
+  return trimGraphemeWhitespace(graphemes).join('') + ellipsis;
+}
+
+/**
+ * Approximate browser line wrapping while remaining deterministic in SVG.
+ * Grapheme segmentation keeps emoji and composed Korean characters intact.
+ */
+function wrapArticleText(
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+  maxLines: number,
+  letterSpacingEm = 0
+): string[] {
+  const normalized = text.replace(/\s+/gu, ' ').trim();
+  if (!normalized) {
+    return [];
+  }
+
+  const source = Array.from(graphemeSegmenter.segment(normalized), (part) => part.segment);
+  const lines: string[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    while (cursor < source.length && /^\s$/u.test(source[cursor])) {
+      cursor += 1;
+    }
+    if (cursor >= source.length) {
+      break;
+    }
+
+    let fittedEnd = cursor;
+    while (fittedEnd < source.length) {
+      const candidate = source.slice(cursor, fittedEnd + 1);
+      if (fittedEnd > cursor && measureGraphemes(candidate, fontSize, letterSpacingEm) > maxWidth) {
+        break;
+      }
+      fittedEnd += 1;
+    }
+
+    let lineEnd = fittedEnd;
+    let nextStart = fittedEnd;
+    if (fittedEnd < source.length) {
+      const whitespaceOffset = findLastWhitespace(source.slice(cursor, fittedEnd));
+      if (whitespaceOffset > 0) {
+        lineEnd = cursor + whitespaceOffset;
+        nextStart = lineEnd + 1;
+        while (nextStart < source.length && /^\s$/u.test(source[nextStart])) {
+          nextStart += 1;
+        }
+      }
+
+      while (nextStart < source.length && PROHIBITED_LINE_START.test(source[nextStart])) {
+        if (lineEnd - cursor <= 1) {
+          const currentLine = trimGraphemeWhitespace(source.slice(cursor, lineEnd)).join('');
+          const visibleLines = [...lines, currentLine].filter(Boolean).slice(0, maxLines);
+          if (visibleLines.length === 0) {
+            return ['…'];
+          }
+          visibleLines[visibleLines.length - 1] = appendEllipsis(
+            visibleLines[visibleLines.length - 1],
+            maxWidth,
+            fontSize,
+            letterSpacingEm
+          );
+          return visibleLines;
+        }
+        lineEnd -= 1;
+        nextStart = lineEnd;
+      }
+
+      let legalLineEnd = lineEnd;
+      while (legalLineEnd > cursor && PROHIBITED_LINE_END.test(source[legalLineEnd - 1])) {
+        legalLineEnd -= 1;
+      }
+      if (legalLineEnd === cursor) {
+        const visibleLines = lines.slice(0, maxLines);
+        if (visibleLines.length === 0) {
+          return ['…'];
+        }
+        visibleLines[visibleLines.length - 1] = appendEllipsis(
+          visibleLines[visibleLines.length - 1],
+          maxWidth,
+          fontSize,
+          letterSpacingEm
+        );
+        return visibleLines;
+      }
+      if (legalLineEnd !== lineEnd) {
+        lineEnd = legalLineEnd;
+        nextStart = lineEnd;
+      }
+    }
+
+    const line = trimGraphemeWhitespace(source.slice(cursor, lineEnd));
+    if (line.length > 0) {
+      lines.push(line.join(''));
+    }
+
+    cursor = nextStart > cursor ? nextStart : cursor + 1;
+  }
+  if (lines.length <= maxLines) {
+    return lines;
+  }
+
+  const visibleLines = lines.slice(0, maxLines);
+  visibleLines[maxLines - 1] = appendEllipsis(
+    visibleLines[maxLines - 1],
+    maxWidth,
+    fontSize,
+    letterSpacingEm
+  );
+  return visibleLines;
+}
+
+function fitSingleLine(
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+  letterSpacingEm = 0
+): string {
+  return wrapArticleText(text, maxWidth, fontSize, 1, letterSpacingEm)[0] || '';
+}
+
+function renderTextBlock({
+  lines,
+  x,
+  firstBaseline,
+  fontSize,
+  lineHeight,
+  className,
+  anchor = 'start',
+}: TextBlockOptions): string {
+  return lines
+    .map(
+      (line, index) =>
+        '<text x="' +
+        x +
+        '" y="' +
+        (firstBaseline + index * fontSize * lineHeight) +
+        '" class="' +
+        className +
+        '" text-anchor="' +
+        anchor +
+        '">' +
+        escapeXml(line) +
+        '</text>'
+    )
+    .join('');
+}
+
+function domainFor(metadata: ExtractedMetadata): string {
+  if (metadata.domain?.trim()) {
+    return metadata.domain.trim().replace(/^www\./i, '');
+  }
+
+  try {
+    return new URL(metadata.url).hostname.replace(/^www\./i, '');
+  } catch {
+    return '';
+  }
+}
+
+function normalizedIdentity(value: string): string {
+  return value
+    .trim()
+    .replace(/^www\./i, '')
+    .toLowerCase();
+}
+
+function createViewport(width: number, height: number, stacked: boolean): ArticleViewport {
+  if (stacked) {
+    return {
+      x: 0,
+      y: 0,
+      width: STACKED_LAYOUT_WIDTH,
+      height: (STACKED_LAYOUT_WIDTH * height) / width,
+    };
+  }
+
+  const scale = Math.min(width / BASE_WIDTH, height / BASE_HEIGHT);
+  const viewportWidth = width / scale;
+  const viewportHeight = height / scale;
+
+  return {
+    x: (BASE_WIDTH - viewportWidth) / 2,
+    y: (BASE_HEIGHT - viewportHeight) / 2,
+    width: viewportWidth,
+    height: viewportHeight,
+  };
+}
+
+function createMobilePanel(
+  metadata: ExtractedMetadata,
+  description: string,
+  primaryColor: string,
+  siteName: string,
+  domain: string,
+  layout: MobilePanelLayout
+): string {
+  const panelTitleFontSize = 34 * layout.scale;
+  const panelTitleLineHeight = 1.14;
+  const panelSummaryFontSize = 22 * layout.scale;
+  const panelSummaryLineHeight = 1.46;
+  const panelSiteFontSize = 17 * layout.scale;
+  const panelDomainFontSize = 17 * layout.scale;
+  const horizontalPadding = 40 * layout.scale;
+  const panelTitleWidth = layout.width - horizontalPadding * 2;
+  const panelTitleLines = wrapArticleText(
+    metadata.title,
+    panelTitleWidth,
+    panelTitleFontSize,
+    3,
+    -0.03
+  );
+  const panelTitleFirstBaseline = 118 * layout.scale;
+  const panelTitleHeight = panelTitleLines.length * panelTitleFontSize * panelTitleLineHeight;
+  const summaryY = panelTitleFirstBaseline + panelTitleHeight + 22 * layout.scale;
+  const dividerY = layout.height - 70 * layout.scale;
+  const summaryBottom = dividerY - 76 * layout.scale;
+  const summaryHeight = Math.min(
+    196 * layout.scale,
+    Math.max(132 * layout.scale, summaryBottom - summaryY)
+  );
+  const summaryLines = wrapArticleText(
+    description,
+    layout.width - 104 * layout.scale,
+    panelSummaryFontSize,
+    Math.max(
+      2,
+      Math.floor(
+        (summaryHeight - 42 * layout.scale) / (panelSummaryFontSize * panelSummaryLineHeight)
+      )
+    ),
+    -0.015
+  );
+  const compactSiteName = fitSingleLine(
+    siteName,
+    layout.width - 132 * layout.scale,
+    panelSiteFontSize,
+    -0.01
+  );
+  const compactDomain = fitSingleLine(
+    domain || siteName,
+    layout.width - 108 * layout.scale,
+    panelDomainFontSize
+  );
+  const className = layout.stacked
+    ? 'article-mobile-preview article-mobile-preview-stacked'
+    : 'article-mobile-preview article-mobile-preview-split';
+
+  return (
+    '<g class="' +
+    className +
+    '" transform="translate(' +
+    layout.x +
+    ' ' +
+    layout.y +
+    ')">' +
+    '<rect x="0" y="0" width="' +
+    layout.width +
+    '" height="' +
+    layout.height +
+    '" rx="' +
+    34 * layout.scale +
+    '" fill="#FFFFFF" class="article-mobile-panel" filter="url(#article-card-shadow)"/>' +
+    '<rect x="' +
+    40 * layout.scale +
+    '" y="' +
+    42 * layout.scale +
+    '" width="' +
+    34 * layout.scale +
+    '" height="' +
+    5 * layout.scale +
+    '" rx="' +
+    2.5 * layout.scale +
+    '" fill="' +
+    primaryColor +
+    '"/>' +
+    '<text x="' +
+    86 * layout.scale +
+    '" y="' +
+    52 * layout.scale +
+    '" class="article-panel-site">' +
+    escapeXml(compactSiteName) +
+    '</text>' +
+    renderTextBlock({
+      lines: panelTitleLines,
+      x: horizontalPadding,
+      firstBaseline: panelTitleFirstBaseline,
+      fontSize: panelTitleFontSize,
+      lineHeight: panelTitleLineHeight,
+      className: 'article-panel-title',
+    }) +
+    '<rect x="' +
+    32 * layout.scale +
+    '" y="' +
+    summaryY +
+    '" width="' +
+    (layout.width - 64 * layout.scale) +
+    '" height="' +
+    summaryHeight +
+    '" rx="' +
+    22 * layout.scale +
+    '" fill="' +
+    primaryColor +
+    '" opacity="0.09"/>' +
+    renderTextBlock({
+      lines: summaryLines,
+      x: 52 * layout.scale,
+      firstBaseline: summaryY + 38 * layout.scale,
+      fontSize: panelSummaryFontSize,
+      lineHeight: panelSummaryLineHeight,
+      className: 'article-summary',
+    }) +
+    '<line x1="' +
+    40 * layout.scale +
+    '" y1="' +
+    dividerY +
+    '" x2="' +
+    (layout.width - 40 * layout.scale) +
+    '" y2="' +
+    dividerY +
+    '" stroke="#E5E8EB" stroke-width="' +
+    2 * layout.scale +
+    '"/>' +
+    '<circle cx="' +
+    50 * layout.scale +
+    '" cy="' +
+    (layout.height - 37 * layout.scale) +
+    '" r="' +
+    6 * layout.scale +
+    '" fill="' +
+    primaryColor +
+    '"/>' +
+    '<text x="' +
+    68 * layout.scale +
+    '" y="' +
+    (layout.height - 30 * layout.scale) +
+    '" class="article-panel-domain">' +
+    escapeXml(compactDomain) +
+    '</text>' +
+    '</g>'
+  );
+}
+
+/**
+ * Generate the article template SVG overlay.
+ */
+export function generateArticleOverlay(
+  metadata: ExtractedMetadata,
+  width: number,
+  height: number,
+  options: PreviewOptions = {},
+  template: TemplateConfig = articleTemplate
+): string {
+  const primaryColor = validateColor(
+    options.colors?.primary || options.colors?.accent || DEFAULT_PRIMARY
+  );
+  const backgroundColor = validateColor(options.colors?.background || DEFAULT_BACKGROUND);
+  const textColor = validateColor(options.colors?.text || DEFAULT_TEXT);
+  const secondaryColor = validateColor(options.colors?.secondary || DEFAULT_SECONDARY);
+  const description = metadata.description?.trim() || '';
+  const showMobilePreview = options.mobilePreview !== false && description.length > 0;
+  const stackedLayout = width / height <= STACKED_LAYOUT_MAX_ASPECT_RATIO;
+  const viewport = createViewport(width, height, stackedLayout);
+  const stackedLayoutProgress = stackedLayout
+    ? Math.max(0, Math.min(1, (viewport.height - 840) / 360))
+    : 0;
+  const domain = domainFor(metadata);
+  const siteName = metadata.siteName?.trim() || domain || 'ARTICLE';
+  const showBrandDomain =
+    domain.length > 0 && normalizedIdentity(domain) !== normalizedIdentity(siteName);
+  const brandFontSize = stackedLayout ? 28 + 6 * stackedLayoutProgress : 20;
+  const brandDomainFontSize = stackedLayout ? 22 + 5 * stackedLayoutProgress : 18;
+  const brandTextMaxWidth = stackedLayout ? 840 + 80 * stackedLayoutProgress : 520;
+  const compactSiteName = fitSingleLine(siteName, brandTextMaxWidth, brandFontSize, -0.01);
+  const compactDomain = showBrandDomain
+    ? fitSingleLine(domain, brandTextMaxWidth, brandDomainFontSize)
+    : '';
+
+  const titleFontSize = stackedLayout
+    ? 60 + 18 * stackedLayoutProgress
+    : showMobilePreview
+      ? template.typography.title.fontSize
+      : 74;
+  const titleLineHeight = template.typography.title.lineHeight || 1.12;
+  const titleMaxLines = template.typography.title.maxLines || 3;
+  const titleMaxWidth = stackedLayout ? 1040 : showMobilePreview ? 600 : 1000;
+  const titleLines = wrapArticleText(
+    metadata.title,
+    titleMaxWidth,
+    titleFontSize,
+    titleMaxLines,
+    -0.035
+  );
+  const descriptionFontSize = stackedLayout
+    ? 28 + 6 * stackedLayoutProgress
+    : template.typography.description?.fontSize || 28;
+  const descriptionLineHeight = template.typography.description?.lineHeight || 1.45;
+  const descriptionLines =
+    !showMobilePreview && description
+      ? wrapArticleText(
+          description,
+          stackedLayout ? 1040 : 940,
+          descriptionFontSize,
+          template.typography.description?.maxLines || 3,
+          -0.012
+        )
+      : [];
+
+  let articleContent: string;
+  let mobilePanelLayout: MobilePanelLayout | undefined;
+
+  if (stackedLayout && showMobilePreview) {
+    const titleBlockHeight = titleLines.length * titleFontSize * titleLineHeight;
+    const panelWidth = Math.min(840 + 80 * stackedLayoutProgress, viewport.width - 160);
+    const desiredPanelHeight = Math.min(1100, Math.max(360, viewport.height * 0.48));
+    const layoutReserve = 180 + 80 * stackedLayoutProgress;
+    const panelHeight = Math.min(
+      desiredPanelHeight,
+      Math.max(340, viewport.height - titleBlockHeight - layoutReserve)
+    );
+    const panelScale = Math.min(panelWidth / 392, panelHeight / 546);
+    const stackGap = 40 + 30 * stackedLayoutProgress;
+    const stackHeight = titleBlockHeight + stackGap + panelHeight;
+    const bottomReserve = 100 + 60 * stackedLayoutProgress;
+    const minimumTop = 50 + 30 * stackedLayoutProgress;
+    const titleTop = Math.max(minimumTop, (viewport.height - bottomReserve - stackHeight) / 2);
+
+    mobilePanelLayout = {
+      x: (viewport.width - panelWidth) / 2,
+      y: titleTop + titleBlockHeight + stackGap,
+      width: panelWidth,
+      height: panelHeight,
+      scale: panelScale,
+      stacked: true,
+    };
+    articleContent =
+      '<rect x="80" y="' +
+      Math.max(42, titleTop - 34) +
+      '" width="56" height="8" rx="4" fill="' +
+      primaryColor +
+      '"/>' +
+      renderTextBlock({
+        lines: titleLines,
+        x: 80,
+        firstBaseline: titleTop + titleFontSize,
+        fontSize: titleFontSize,
+        lineHeight: titleLineHeight,
+        className: 'article-title',
+      });
+  } else if (stackedLayout) {
+    const titleBlockHeight = titleLines.length * titleFontSize * titleLineHeight;
+    const descriptionBlockHeight =
+      descriptionLines.length * descriptionFontSize * descriptionLineHeight;
+    const gap = descriptionLines.length > 0 ? 42 : 0;
+    const contentHeight = titleBlockHeight + gap + descriptionBlockHeight;
+    const contentTop = Math.max(100, (viewport.height - 180 - contentHeight) / 2);
+
+    articleContent =
+      '<rect x="80" y="' +
+      Math.max(60, contentTop - 34) +
+      '" width="56" height="8" rx="4" fill="' +
+      primaryColor +
+      '"/>' +
+      renderTextBlock({
+        lines: titleLines,
+        x: 80,
+        firstBaseline: contentTop + titleFontSize,
+        fontSize: titleFontSize,
+        lineHeight: titleLineHeight,
+        className: 'article-title',
+      }) +
+      renderTextBlock({
+        lines: descriptionLines,
+        x: 80,
+        firstBaseline: contentTop + titleBlockHeight + gap + descriptionFontSize,
+        fontSize: descriptionFontSize,
+        lineHeight: descriptionLineHeight,
+        className: 'article-description',
+      });
+  } else if (showMobilePreview) {
+    const titleBlockHeight = titleLines.length * titleFontSize * titleLineHeight;
+    const titleTop = Math.max(132, (BASE_HEIGHT - titleBlockHeight) / 2 - 8);
+    mobilePanelLayout = {
+      x: 748,
+      y: 42,
+      width: 392,
+      height: 546,
+      scale: 1,
+      stacked: false,
+    };
+    articleContent =
+      '<rect x="80" y="' +
+      Math.max(96, titleTop - 34) +
+      '" width="48" height="8" rx="4" fill="' +
+      primaryColor +
+      '"/>' +
+      renderTextBlock({
+        lines: titleLines,
+        x: 80,
+        firstBaseline: titleTop + titleFontSize,
+        fontSize: titleFontSize,
+        lineHeight: titleLineHeight,
+        className: 'article-title',
+      });
+  } else {
+    const centeredLayout = layoutCenteredTitleDescription({
+      height: 510,
+      titleLineCount: titleLines.length,
+      titleFontSize,
+      titleLineHeight,
+      descLineCount: descriptionLines.length,
+      descFontSize: descriptionFontSize,
+      descLineHeight: descriptionLineHeight,
+      gap: 32,
+    });
+
+    articleContent =
+      '<rect x="80" y="' +
+      Math.max(60, centeredLayout.contentStartY + 14) +
+      '" width="56" height="8" rx="4" fill="' +
+      primaryColor +
+      '"/>' +
+      renderTextBlock({
+        lines: titleLines,
+        x: 80,
+        firstBaseline: centeredLayout.titleStartY + 48,
+        fontSize: titleFontSize,
+        lineHeight: titleLineHeight,
+        className: 'article-title',
+      }) +
+      renderTextBlock({
+        lines: descriptionLines,
+        x: 80,
+        firstBaseline: centeredLayout.descStartY + 48,
+        fontSize: descriptionFontSize,
+        lineHeight: descriptionLineHeight,
+        className: 'article-description',
+      });
+  }
+
+  const mobileContent = mobilePanelLayout
+    ? createMobilePanel(metadata, description, primaryColor, siteName, domain, mobilePanelLayout)
+    : '';
+  const panelScale = mobilePanelLayout?.scale || 1;
+  const brandCircleX = stackedLayout ? 100 : 88;
+  const brandCircleY = stackedLayout ? viewport.height - 74 : 554;
+  const brandTextX = stackedLayout ? 128 : 108;
+  const brandTextY = brandCircleY + 7;
+  const brandDomainY = brandCircleY + (stackedLayout ? 40 : 34);
+  const brandCircleRadius = stackedLayout ? 10 : 8;
+
+  const svgStyle = createSvgStyleCdata(
+    [
+      '.article-title { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        titleFontSize +
+        'px; font-weight: 800; fill: ' +
+        textColor +
+        '; letter-spacing: -0.035em; }',
+      '.article-description { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        descriptionFontSize +
+        'px; font-weight: 400; fill: ' +
+        secondaryColor +
+        '; letter-spacing: -0.012em; }',
+      '.article-brand { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        brandFontSize +
+        'px; font-weight: 700; fill: ' +
+        textColor +
+        '; letter-spacing: -0.01em; }',
+      '.article-domain { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        brandDomainFontSize +
+        'px; font-weight: 500; fill: ' +
+        secondaryColor +
+        '; }',
+      '.article-panel-site { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        17 * panelScale +
+        'px; font-weight: 700; fill: ' +
+        secondaryColor +
+        '; letter-spacing: -0.01em; }',
+      '.article-panel-title { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        34 * panelScale +
+        'px; font-weight: 800; fill: ' +
+        textColor +
+        '; letter-spacing: -0.03em; }',
+      '.article-summary { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        22 * panelScale +
+        'px; font-weight: 500; fill: ' +
+        textColor +
+        '; letter-spacing: -0.015em; }',
+      '.article-panel-domain { font-family: ' +
+        SYSTEM_FONT_STACK +
+        '; font-size: ' +
+        17 * panelScale +
+        'px; font-weight: 600; fill: ' +
+        secondaryColor +
+        '; }',
+    ].join('\n')
+  );
+
+  return (
+    '<svg width="' +
+    width +
+    '" height="' +
+    height +
+    '" viewBox="' +
+    viewport.x +
+    ' ' +
+    viewport.y +
+    ' ' +
+    viewport.width +
+    ' ' +
+    viewport.height +
+    '" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">' +
+    '<defs>' +
+    svgStyle +
+    '<filter id="article-card-shadow" x="-30%" y="-20%" width="160%" height="160%">' +
+    '<feDropShadow dx="0" dy="' +
+    18 * panelScale +
+    '" stdDeviation="' +
+    24 * panelScale +
+    '" flood-color="#191F28" flood-opacity="0.12"/>' +
+    '</filter>' +
+    '</defs>' +
+    '<rect x="' +
+    viewport.x +
+    '" y="' +
+    viewport.y +
+    '" width="' +
+    viewport.width +
+    '" height="' +
+    viewport.height +
+    '" fill="' +
+    backgroundColor +
+    '"/>' +
+    articleContent +
+    mobileContent +
+    '<g class="article-branding">' +
+    '<circle cx="' +
+    brandCircleX +
+    '" cy="' +
+    brandCircleY +
+    '" r="' +
+    brandCircleRadius +
+    '" fill="' +
+    primaryColor +
+    '"/>' +
+    '<text x="' +
+    brandTextX +
+    '" y="' +
+    brandTextY +
+    '" class="article-brand">' +
+    escapeXml(compactSiteName) +
+    '</text>' +
+    (compactDomain
+      ? '<text x="' +
+        brandTextX +
+        '" y="' +
+        brandDomainY +
+        '" class="article-domain">' +
+        escapeXml(compactDomain) +
+        '</text>'
+      : '') +
+    '</g>' +
+    '</svg>'
+  );
+}

--- a/src/templates/registry.ts
+++ b/src/templates/registry.ts
@@ -1,4 +1,5 @@
 import { TemplateConfig } from '../types';
+import { articleTemplate } from './article';
 import { classicTemplate } from './classic';
 import { minimalTemplate } from './minimal';
 import { modernTemplate } from './modern';
@@ -7,5 +8,5 @@ export const templates: Record<string, TemplateConfig> = {
   modern: modernTemplate,
   classic: classicTemplate,
   minimal: minimalTemplate,
+  article: articleTemplate,
 };
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,8 @@ export type SanitizedOptions = Brand<PreviewOptions, 'SanitizedOptions'>;
 export interface PreviewOptions {
   /** Template to use for generating the preview */
   template?: TemplateType;
+  /** Show the mobile article preview in the article template (default: true when description exists) */
+  mobilePreview?: boolean;
   /** Width of the generated image in pixels */
   width?: number;
   /** Height of the generated image in pixels */
@@ -96,7 +98,7 @@ export interface RedirectResponseDetails {
 /**
  * Available template types
  */
-export type TemplateType = 'modern' | 'classic' | 'minimal';
+export type TemplateType = 'modern' | 'classic' | 'minimal' | 'article';
 
 /**
  * Fallback options for handling missing metadata

--- a/src/utils/validators/options.ts
+++ b/src/utils/validators/options.ts
@@ -247,6 +247,13 @@ export function sanitizeOptions(options: PreviewOptions): SanitizedOptions {
     );
   }
 
+  if (sanitized.mobilePreview !== undefined && typeof sanitized.mobilePreview !== 'boolean') {
+    throw new PreviewGeneratorError(
+      ErrorType.VALIDATION_ERROR,
+      `Mobile preview option must be boolean, got: ${typeof sanitized.mobilePreview}`
+    );
+  }
+
   // Validate text inputs from fallback
   if (sanitized.fallback?.text) {
     sanitized.fallback = {

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -7,7 +7,7 @@ import {
   generatePreviewFromMetadataWithDetails,
   generatePreviewWithDetails,
 } from '../../src/index';
-import { ErrorType, PreviewOptions } from '../../src/types';
+import { ErrorType, PreviewOptions, TemplateType } from '../../src/types';
 import axios from 'axios';
 import ogs from 'open-graph-scraper';
 import sharp from 'sharp';
@@ -231,7 +231,7 @@ describe('End-to-End Integration Tests', () => {
       const url = 'https://example.com';
 
       // Test each template with custom colors
-      const templates: Array<'modern' | 'classic' | 'minimal'> = ['modern', 'classic', 'minimal'];
+      const templates: TemplateType[] = ['modern', 'classic', 'minimal', 'article'];
 
       for (const template of templates) {
         const options: PreviewOptions = {
@@ -267,7 +267,7 @@ describe('End-to-End Integration Tests', () => {
         response: {} as any,
       });
 
-      const templates: Array<'modern' | 'classic' | 'minimal'> = ['modern', 'classic', 'minimal'];
+      const templates: TemplateType[] = ['modern', 'classic', 'minimal', 'article'];
 
       for (const template of templates) {
         const result = await generatePreview(url, { template });

--- a/test/integration/render-dimensions.test.ts
+++ b/test/integration/render-dimensions.test.ts
@@ -30,7 +30,7 @@ describe('generated image dimensions with real Sharp', () => {
     await expectImageDimensions(buffer, width, height);
   });
 
-  it.each(['classic', 'minimal'] as const)(
+  it.each(['classic', 'minimal', 'article'] as const)(
     'keeps the %s template at the requested dimensions',
     async (template) => {
       const width = 320;
@@ -44,6 +44,19 @@ describe('generated image dimensions with real Sharp', () => {
       await expectImageDimensions(buffer, width, height);
     }
   );
+
+  it.each([
+    { width: 800, height: 800 },
+    { width: 400, height: 800 },
+  ])('renders a stacked article preview at $width x $height', async ({ width, height }) => {
+    const buffer = await generatePreviewFromMetadata(directMetadata, {
+      template: 'article',
+      width,
+      height,
+    });
+
+    await expectImageDimensions(buffer, width, height);
+  });
 
   it('renders a custom template through the default overlay at the requested dimensions', async () => {
     const width = 320;

--- a/test/unit/templates/article.test.ts
+++ b/test/unit/templates/article.test.ts
@@ -1,0 +1,332 @@
+import { articleTemplate, generateArticleOverlay } from '../../../src/templates/article';
+import { templates } from '../../../src/templates/registry';
+import type { ExtractedMetadata, PreviewOptions } from '../../../src/types';
+
+function elementMarkupByClass(svg: string, className: string, tagName: string): string[] {
+  const classPattern = `class="[^"]*\\b${className}\\b[^"]*"`;
+  const pattern = new RegExp(
+    `<${tagName}\\b[^>]*${classPattern}[^>]*>[\\s\\S]*?<\\/${tagName}>`,
+    'g'
+  );
+
+  return svg.match(pattern) ?? [];
+}
+
+function openingTagsByClass(
+  svg: string,
+  className: string,
+  tagName = '[a-zA-Z][\\w:-]*'
+): string[] {
+  const classPattern = `class="[^"]*\\b${className}\\b[^"]*"`;
+  const pattern = new RegExp(`<${tagName}\\b[^>]*${classPattern}[^>]*>`, 'g');
+
+  return svg.match(pattern) ?? [];
+}
+
+function numericAttribute(markup: string, name: string): number {
+  const match = markup.match(new RegExp(`\\b${name}="([^"]+)"`));
+  if (!match) {
+    throw new Error(`Missing ${name} in ${markup}`);
+  }
+  return Number(match[1]);
+}
+
+function translation(markup: string): { x: number; y: number } {
+  const match = markup.match(/\btransform="translate\(([^ ]+) ([^)]+)\)"/);
+  if (!match) {
+    throw new Error(`Missing translation in ${markup}`);
+  }
+  return { x: Number(match[1]), y: Number(match[2]) };
+}
+
+function viewBox(svg: string): { x: number; y: number; width: number; height: number } {
+  const match = svg.match(/\bviewBox="([^ ]+) ([^ ]+) ([^ ]+) ([^"]+)"/);
+  if (!match) {
+    throw new Error('Missing viewBox');
+  }
+  return {
+    x: Number(match[1]),
+    y: Number(match[2]),
+    width: Number(match[3]),
+    height: Number(match[4]),
+  };
+}
+
+describe('Article Template', () => {
+  const metadata: ExtractedMetadata = {
+    title: '좋은 제품은 복잡한 정보를 누구나 이해할 수 있게 정리합니다',
+    description: '핵심 내용을 모바일 카드에서 빠르게 확인할 수 있습니다.',
+    siteName: 'NANGGO LAB',
+    url: 'https://example.com/article',
+    domain: 'example.com',
+  };
+
+  it('registers the additive article template contract', () => {
+    expect(articleTemplate.name).toBe('article');
+    expect(articleTemplate.overlayGenerator).toBe(generateArticleOverlay);
+    expect(templates.article).toBe(articleTemplate);
+  });
+
+  it('shows the mobile preview panel and summary by default when a description exists', () => {
+    const svg = generateArticleOverlay(metadata, 1200, 630, {});
+
+    expect(openingTagsByClass(svg, 'article-mobile-panel')).toHaveLength(1);
+    expect(elementMarkupByClass(svg, 'article-summary', 'text').length).toBeGreaterThan(0);
+    expect(svg).toContain('핵심 내용을 모바일 카드에서');
+  });
+
+  it('hides the mobile panel and reflows the article content when mobilePreview is false', () => {
+    const splitSvg = generateArticleOverlay(metadata, 1200, 630, {});
+    const reflowedSvg = generateArticleOverlay(metadata, 1200, 630, {
+      mobilePreview: false,
+    });
+
+    expect(openingTagsByClass(reflowedSvg, 'article-mobile-panel')).toHaveLength(0);
+    expect(elementMarkupByClass(reflowedSvg, 'article-summary', 'text')).toHaveLength(0);
+    expect(elementMarkupByClass(reflowedSvg, 'article-title', 'text')).not.toEqual(
+      elementMarkupByClass(splitSvg, 'article-title', 'text')
+    );
+  });
+
+  it('omits the mobile panel when there is no description', () => {
+    const svg = generateArticleOverlay({ ...metadata, description: undefined }, 1200, 630, {});
+
+    expect(openingTagsByClass(svg, 'article-mobile-panel')).toHaveLength(0);
+    expect(elementMarkupByClass(svg, 'article-summary', 'text')).toHaveLength(0);
+  });
+
+  it('uses colors.primary ahead of colors.accent for the article accent', () => {
+    const options: PreviewOptions = {
+      colors: {
+        primary: '#7C3AED',
+        accent: '#F97316',
+      },
+    };
+
+    const svg = generateArticleOverlay(metadata, 1200, 630, options);
+
+    expect(svg).toContain('#7C3AED');
+    expect(svg).not.toContain('#F97316');
+  });
+
+  it.each([
+    { width: 1200, height: 630 },
+    { width: 320, height: 168 },
+  ])('keeps the article layout inside a $width x $height root SVG', ({ width, height }) => {
+    const svg = generateArticleOverlay(metadata, width, height, {});
+
+    expect(svg).toContain(`<svg width="${width}" height="${height}"`);
+    expect(openingTagsByClass(svg, 'article-mobile-panel')).toHaveLength(1);
+    expect(elementMarkupByClass(svg, 'article-title', 'text').length).toBeGreaterThan(0);
+  });
+
+  it('preserves the split mobile layout for the default landscape aspect ratio', () => {
+    const svg = generateArticleOverlay(metadata, 1200, 630, {});
+    const group = openingTagsByClass(svg, 'article-mobile-preview-split', 'g')[0];
+    const panel = openingTagsByClass(svg, 'article-mobile-panel', 'rect')[0];
+
+    expect(translation(group)).toEqual({ x: 748, y: 42 });
+    expect(numericAttribute(panel, 'width')).toBe(392);
+    expect(numericAttribute(panel, 'height')).toBe(546);
+    expect(svg).not.toContain('article-mobile-preview-stacked');
+  });
+
+  it.each([
+    { width: 800, height: 800, logicalHeight: 1200 },
+    { width: 400, height: 800, logicalHeight: 2400 },
+  ])(
+    'stacks a full-size mobile panel inside a $width x $height viewport',
+    ({ width, height, logicalHeight }) => {
+      const svg = generateArticleOverlay(metadata, width, height, {});
+      const group = openingTagsByClass(svg, 'article-mobile-preview-stacked', 'g')[0];
+      const panel = openingTagsByClass(svg, 'article-mobile-panel', 'rect')[0];
+      const position = translation(group);
+      const panelWidth = numericAttribute(panel, 'width');
+      const panelHeight = numericAttribute(panel, 'height');
+
+      expect(svg).toContain(`viewBox="0 0 1200 ${logicalHeight}"`);
+      expect(panelWidth).toBeGreaterThanOrEqual(900);
+      expect(panelHeight).toBeGreaterThanOrEqual(570);
+      expect(position.x).toBeGreaterThanOrEqual(0);
+      expect(position.x + panelWidth).toBeLessThanOrEqual(1200);
+      expect(position.y).toBeGreaterThan(0);
+      expect(position.y + panelHeight).toBeLessThan(logicalHeight - 100);
+    }
+  );
+
+  it.each([
+    { width: 801, height: 800 },
+    { width: 1000, height: 800 },
+  ])('keeps a near-square $width x $height output in the stacked layout', ({ width, height }) => {
+    const svg = generateArticleOverlay(metadata, width, height, {});
+    const viewport = viewBox(svg);
+    const panel = openingTagsByClass(svg, 'article-mobile-panel', 'rect')[0];
+    const group = openingTagsByClass(svg, 'article-mobile-preview-stacked', 'g')[0];
+    const position = translation(group);
+
+    expect(viewport).toEqual({ x: 0, y: 0, width: 1200, height: (1200 * height) / width });
+    expect(openingTagsByClass(svg, 'article-mobile-preview-split', 'g')).toHaveLength(0);
+    expect(position.x + numericAttribute(panel, 'width')).toBeLessThanOrEqual(viewport.width);
+    expect(position.y + numericAttribute(panel, 'height')).toBeLessThan(viewport.height - 90);
+  });
+
+  it('keeps a clearly landscape output in the split layout', () => {
+    const svg = generateArticleOverlay(metadata, 1200, 800, {});
+
+    expect(openingTagsByClass(svg, 'article-mobile-preview-split', 'g')).toHaveLength(1);
+    expect(openingTagsByClass(svg, 'article-mobile-preview-stacked', 'g')).toHaveLength(0);
+  });
+
+  it('keeps the stacked text-only state when mobilePreview is false', () => {
+    const svg = generateArticleOverlay(metadata, 400, 800, { mobilePreview: false });
+
+    expect(svg).toContain('viewBox="0 0 1200 2400"');
+    expect(openingTagsByClass(svg, 'article-mobile-panel')).toHaveLength(0);
+    expect(elementMarkupByClass(svg, 'article-description', 'text').length).toBeGreaterThan(0);
+  });
+
+  it('omits the stacked mobile panel when no description exists', () => {
+    const svg = generateArticleOverlay({ ...metadata, description: undefined }, 400, 800, {});
+
+    expect(openingTagsByClass(svg, 'article-mobile-panel')).toHaveLength(0);
+    expect(elementMarkupByClass(svg, 'article-summary', 'text')).toHaveLength(0);
+  });
+
+  it('wraps an unspaced Korean title without dropping it into a single truncated line', () => {
+    const koreanTitle =
+      '사용자가복잡한설명없이도핵심정보를빠르게이해하고다음행동을선택할수있는제품디자인원칙';
+    const svg = generateArticleOverlay({ ...metadata, title: koreanTitle }, 1200, 630, {});
+    const titleLines = elementMarkupByClass(svg, 'article-title', 'text');
+
+    expect(titleLines.length).toBeGreaterThan(1);
+    expect(titleLines.length).toBeLessThanOrEqual(articleTemplate.typography.title.maxLines ?? 3);
+    expect(titleLines.join('')).not.toContain('�');
+    expect(titleLines[0]).toContain('사용자가');
+  });
+
+  it('accounts for wide Latin glyphs instead of letting them overrun the title region', () => {
+    const wideTitle = 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWW';
+    const svg = generateArticleOverlay({ ...metadata, title: wideTitle }, 1200, 630, {});
+    const titleLines = elementMarkupByClass(svg, 'article-title', 'text');
+
+    expect(titleLines.length).toBeGreaterThan(1);
+    expect(titleLines).toHaveLength(articleTemplate.typography.title.maxLines ?? 3);
+    expect(titleLines[0]).not.toContain('WWWWWWWWWWW');
+    expect(titleLines.at(-1)).toContain('…');
+  });
+
+  it.each([
+    { name: 'regional-indicator flags', grapheme: '🇰🇷', expectedLines: 3 },
+    { name: 'keycap sequences', grapheme: '1️⃣', expectedLines: 3 },
+    { name: 'fullwidth Latin forms', grapheme: 'Ｍ', expectedLines: 3 },
+    { name: 'fullwidth CJK punctuation', grapheme: '。', expectedLines: 1 },
+    { name: 'non-ASCII math symbols', grapheme: '∑', expectedLines: 3 },
+  ])('accounts for wide $name as complete graphemes', ({ grapheme, expectedLines }) => {
+    const title = grapheme.repeat(30);
+    const svg = generateArticleOverlay({ ...metadata, title }, 1200, 630, {});
+    const titleLines = elementMarkupByClass(svg, 'article-title', 'text');
+
+    expect(titleLines).toHaveLength(expectedLines);
+    expect(titleLines[0]).not.toContain(grapheme.repeat(10));
+    expect(titleLines.at(-1)).toContain('…');
+    expect(titleLines.join('')).not.toContain('�');
+  });
+
+  it('keeps a realistic punctuation-heavy English title without premature ellipsis', () => {
+    const title = "What's new in GPT-5? Faster, safer, and smarter.";
+    const svg = generateArticleOverlay({ ...metadata, title }, 1200, 630, {});
+    const leftTitle = elementMarkupByClass(svg, 'article-title', 'text').join('');
+    const panelTitle = elementMarkupByClass(svg, 'article-panel-title', 'text').join('');
+
+    expect(leftTitle).not.toContain('…');
+    expect(leftTitle).toContain('smarter.');
+    expect(panelTitle).not.toContain('…');
+    expect(panelTitle).toContain('smarter.');
+  });
+
+  it.each([
+    'あいうえおかきくけ。続きの記事タイトル',
+    'あいうえおかきく「記事タイトルの続き',
+    '一二三四五六七八九，后续文章标题',
+    '一二三四五六七八九。」続き',
+    '一二三四五六七。！？后续文章标题',
+    `${'文'.repeat(9)},続き記事です`,
+    `${'文'.repeat(9)}｡､｣続き記事です`,
+    `${'文'.repeat(9)}ぁぃぅ続き記事です`,
+    `文《${'語'.repeat(6)}》，${'後'.repeat(20)}`,
+    '文お続ぅ文事き文ぇ｡ぁゅ。ゃゃ』》」？',
+  ])('keeps Japanese and Chinese prohibited punctuation off title line boundaries', (title) => {
+    const svg = generateArticleOverlay({ ...metadata, title }, 1200, 630, {});
+    const blocks = [
+      elementMarkupByClass(svg, 'article-title', 'text'),
+      elementMarkupByClass(svg, 'article-panel-title', 'text'),
+    ];
+    const prohibitedStart =
+      /^[!,.?:;、。，．！？；：)\]}」』】〉》〕］｝’”｡､｣ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮヵヶ]/u;
+    const prohibitedEnd = /[(\[{「『【〈《〔［｛‘“｢]$/u;
+
+    for (const lines of blocks) {
+      const textLines = lines.map((line) => line.replace(/<[^>]+>/g, ''));
+      for (const line of textLines.slice(1)) {
+        expect(line).not.toMatch(prohibitedStart);
+      }
+      for (const line of textLines.slice(0, -1)) {
+        expect(line).not.toMatch(prohibitedEnd);
+      }
+    }
+  });
+
+  it('terminates safely when a wrapped segment contains only prohibited line endings', () => {
+    const title = `${'文'.repeat(8)}${'「'.repeat(12)}続`;
+    const startedAt = Date.now();
+    const svg = generateArticleOverlay({ ...metadata, title }, 1200, 630, {});
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(elementMarkupByClass(svg, 'article-title', 'text').join('')).toContain('…');
+    expect(elementMarkupByClass(svg, 'article-panel-title', 'text').join('')).toContain('…');
+  });
+
+  it('keeps closing CJK punctuation off summary line starts', () => {
+    const description = `${'文'.repeat(13)}，后续摘要内容继续显示。`;
+    const svg = generateArticleOverlay({ ...metadata, description }, 1200, 630, {});
+    const summaryLines = elementMarkupByClass(svg, 'article-summary', 'text').map((line) =>
+      line.replace(/<[^>]+>/g, '')
+    );
+
+    expect(summaryLines.length).toBeGreaterThan(1);
+    for (const line of summaryLines.slice(1)) {
+      expect(line).not.toMatch(/^[、。，．！？；：)\]}」』】〉》〕］｝’”]/u);
+    }
+  });
+
+  it('truncates long site and domain labels inside their fixed-width regions', () => {
+    const longSiteName = '아주긴사이트이름이모바일패널의가로폭을넘어가는경우';
+    const longDomain = 'an-extremely-long-domain-name-for-an-article-preview.example.com';
+    const svg = generateArticleOverlay(
+      { ...metadata, siteName: longSiteName, domain: longDomain },
+      1200,
+      630,
+      {}
+    );
+    const panelSite = elementMarkupByClass(svg, 'article-panel-site', 'text').join('');
+    const panelDomain = elementMarkupByClass(svg, 'article-panel-domain', 'text').join('');
+
+    expect(panelSite).toContain('…');
+    expect(panelSite).not.toContain(longSiteName);
+    expect(panelDomain).toContain('…');
+    expect(panelDomain).not.toContain(longDomain);
+  });
+
+  it('does not repeat the hostname on adjacent lower-left branding lines', () => {
+    const svg = generateArticleOverlay(
+      { ...metadata, siteName: 'Example.com', domain: 'www.example.com' },
+      1200,
+      630,
+      {}
+    );
+
+    expect(elementMarkupByClass(svg, 'article-brand', 'text')).toHaveLength(1);
+    expect(elementMarkupByClass(svg, 'article-domain', 'text')).toHaveLength(0);
+    expect(elementMarkupByClass(svg, 'article-panel-domain', 'text')).toHaveLength(1);
+  });
+});

--- a/test/unit/templates/article.test.ts
+++ b/test/unit/templates/article.test.ts
@@ -12,6 +12,16 @@ function elementMarkupByClass(svg: string, className: string, tagName: string): 
   return svg.match(pattern) ?? [];
 }
 
+function textElementContent(markup: string): string {
+  const contentStart = markup.indexOf('>');
+  const contentEnd = markup.lastIndexOf('</text>');
+  if (contentStart < 0 || contentEnd <= contentStart) {
+    throw new Error(`Invalid text element markup: ${markup}`);
+  }
+
+  return markup.slice(contentStart + 1, contentEnd);
+}
+
 function openingTagsByClass(
   svg: string,
   className: string,
@@ -266,7 +276,7 @@ describe('Article Template', () => {
     const prohibitedEnd = /[(\[{「『【〈《〔［｛‘“｢]$/u;
 
     for (const lines of blocks) {
-      const textLines = lines.map((line) => line.replace(/<[^>]+>/g, ''));
+      const textLines = lines.map(textElementContent);
       for (const line of textLines.slice(1)) {
         expect(line).not.toMatch(prohibitedStart);
       }
@@ -289,8 +299,8 @@ describe('Article Template', () => {
   it('keeps closing CJK punctuation off summary line starts', () => {
     const description = `${'文'.repeat(13)}，后续摘要内容继续显示。`;
     const svg = generateArticleOverlay({ ...metadata, description }, 1200, 630, {});
-    const summaryLines = elementMarkupByClass(svg, 'article-summary', 'text').map((line) =>
-      line.replace(/<[^>]+>/g, '')
+    const summaryLines = elementMarkupByClass(svg, 'article-summary', 'text').map(
+      textElementContent
     );
 
     expect(summaryLines.length).toBeGreaterThan(1);

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -306,6 +306,30 @@ describe('Validators', () => {
       expect(sanitizeOptions({ quality }).quality).toBe(quality);
     });
 
+    test.each([true, false])('should preserve mobilePreview=%s', mobilePreview => {
+      const sanitized = sanitizeOptions({ mobilePreview });
+
+      expect(sanitized.mobilePreview).toBe(mobilePreview);
+    });
+
+    test('should accept the article template', () => {
+      expect(sanitizeOptions({ template: 'article' }).template).toBe('article');
+    });
+
+    test.each(['false', 0, 1, null, {}, []])(
+      'should reject non-boolean mobilePreview=%# with VALIDATION_ERROR',
+      mobilePreview => {
+        try {
+          sanitizeOptions({ mobilePreview } as unknown as PreviewOptions);
+          throw new Error('Expected sanitizeOptions to reject mobilePreview');
+        } catch (error) {
+          expect(error).toBeInstanceOf(PreviewGeneratorError);
+          expect((error as PreviewGeneratorError).type).toBe(ErrorType.VALIDATION_ERROR);
+          expect((error as PreviewGeneratorError).message).toMatch(/mobile preview/i);
+        }
+      }
+    );
+
     test.each([
       NaN,
       Infinity,


### PR DESCRIPTION
## Summary

- add a metadata-first `article` template with an optional mobile summary surface
- add `mobilePreview` and `colors.primary` support with Toss-like blue as the default
- stack the article layout for standard near-square and portrait aspect ratios
- handle Korean, Japanese, and Chinese grapheme wrapping and line-boundary punctuation safely
- document the feature in English and Korean while keeping the Korean README out of the npm tarball

## Why

Article and blog publishers need a compact social preview that communicates both the headline and a short mobile-style summary without fetching or screenshotting the original page.

## Impact

The change is additive. `modern` remains the default template, existing template behavior is preserved, and custom dimensions remain available through the existing API.

## Validation

- `pnpm run lint`
- `pnpm run build`
- `pnpm test` — 31 files, 637 tests
- `pnpm run verify:package`
- representative pixel review at 1200x630, 320x168, 800x800, 1000x800, and 400x800
- independent code and visual adversarial reviews: SHIP
- `git diff --check` and selected Prettier checks
