### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanggo/social-preview",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Generate beautiful social media preview images from any URL",
   "packageManager": "pnpm@10.11.0",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump `@nanggo/social-preview` from `0.3.0` to `0.4.0`
- prepare the additive article preview template from #77 for publication

## Release scope

This PR intentionally changes only `package.json`. The root version is not stored in `pnpm-lock.yaml`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run verify:release -- --tag v0.4.0`
- `pnpm run lint`
- `pnpm run build`
- `SKIP_NETWORK_TESTS=true pnpm test` — 31 files, 637 tests
- `pnpm audit --prod --audit-level=high` — no known vulnerabilities
- `pnpm run verify:package`

After merge, an annotated `v0.4.0` tag on the exact merge commit will trigger the OIDC/provenance npm publish workflow.
