### PR TITLE
fix: resolve metadata against final URL

### DIFF
--- a/src/core/image-generator.ts
+++ b/src/core/image-generator.ts
@@ -16,7 +16,7 @@ import { escapeXml, wrapText } from '../utils';
 import { createCachedCanvas, createCachedSVG } from '../utils/sharp-cache';
 import { SYSTEM_FONT_STACK } from '../constants/fonts';
 import { fetchImage } from './metadata-extractor';
-import { createTransparentCanvas, validateColor } from '../utils/validators';
+import { createTransparentCanvas, stripLeadingWww, validateColor } from '../utils/validators';
 import { withPreparedRenderSlot, withRenderSlot } from '../utils/render-limiter';
 
 /**
@@ -366,7 +366,7 @@ export async function createFallbackImageWithDetails(
       description: `Visit ${domain} for more information`,
       url,
       domain,
-      siteName: domain.replace('www.', ''),
+      siteName: stripLeadingWww(domain),
     };
 
     // Use a simple template for fallback

--- a/src/core/metadata-extractor.ts
+++ b/src/core/metadata-extractor.ts
@@ -6,7 +6,12 @@
 import ogs from 'open-graph-scraper';
 import axios from 'axios';
 import { ExtractedMetadata, ErrorType, PreviewGeneratorError, SecurityOptions } from '../types';
-import { validateUrlInput } from '../utils/validators';
+import {
+  getDefaultFaviconUrl,
+  resolveHttpUrl,
+  stripLeadingWww,
+  validateUrlInput,
+} from '../utils/validators';
 import {
   getEnhancedSecureHttpAgent,
   getEnhancedSecureHttpsAgent,
@@ -85,7 +90,11 @@ function findValidationError(error: unknown): PreviewGeneratorError | undefined 
 /**
  * Build redirect validation callback for SSRF protection
  */
-function createRedirectValidator(context: string, httpsOnly: boolean = false) {
+function createRedirectValidator(
+  context: string,
+  httpsOnly: boolean = false,
+  onValidatedRedirect?: (url: string) => void
+) {
   return (
     options: Record<string, unknown>,
     _responseDetails: { headers: Record<string, string>; statusCode: number }
@@ -112,6 +121,8 @@ function createRedirectValidator(context: string, httpsOnly: boolean = false) {
         `${context} blocked by HTTPS-only mode: ${validatedRedirectUrl}`
       );
     }
+
+    onValidatedRedirect?.(validatedRedirectUrl);
   };
 }
 
@@ -300,14 +311,14 @@ async function extractMetadataInternal(
   abortSignal?: AbortSignal
 ): Promise<ExtractedMetadata> {
   // DNS validation and the HTTP response share one total request deadline.
-  const { data: ogData, validatedUrl } = await fetchOpenGraphData(
+  const { data: ogData, finalUrl } = await fetchOpenGraphData(
     url,
     securityOptions,
     abortSignal
   );
 
   // Parse and normalize metadata
-  const metadata = parseMetadata(ogData, validatedUrl);
+  const metadata = parseMetadata(ogData, finalUrl);
 
   // Cache the result
   metadataCache.set(cacheKey, metadata);
@@ -395,7 +406,7 @@ async function fetchOpenGraphData(
   url: string,
   securityOptions?: SecurityOptions,
   abortSignal?: AbortSignal
-): Promise<{ data: Record<string, unknown>; validatedUrl: string }> {
+): Promise<{ data: Record<string, unknown>; finalUrl: string }> {
   const normalizedUrl = validateUrlBeforeNetwork(url, securityOptions);
   const requestTimeout = securityOptions?.timeout || 8000;
   // Create secure axios config with redirect validation and secure agent
@@ -412,20 +423,30 @@ async function fetchOpenGraphData(
     httpAgent: getEnhancedSecureHttpAgent(),
     httpsAgent: getEnhancedSecureHttpsAgent(),
     proxy: false as const,
-    beforeRedirect: createRedirectValidator('Redirect', securityOptions?.httpsOnly === true),
   };
 
   // Phase 1: Fetch HTML through secure agent
   let html: string;
-  let validatedUrl: string;
+  let finalUrl: string;
   try {
     const fetched = await runControlledNetworkRequest(
       requestTimeout,
       abortSignal,
       async signal => {
         const requestUrl = await validateUrlSecurity(normalizedUrl, signal);
-        const response = await axios.get(requestUrl, { ...axiosConfig, signal });
-        return { response, validatedUrl: requestUrl };
+        let responseUrl = requestUrl;
+        const response = await axios.get(requestUrl, {
+          ...axiosConfig,
+          signal,
+          beforeRedirect: createRedirectValidator(
+            'Redirect',
+            securityOptions?.httpsOnly === true,
+            redirectUrl => {
+              responseUrl = redirectUrl;
+            }
+          ),
+        });
+        return { response, finalUrl: responseUrl };
       }
     );
 
@@ -434,7 +455,7 @@ async function fetchOpenGraphData(
     }
 
     html = fetched.response.data;
-    validatedUrl = fetched.validatedUrl;
+    finalUrl = fetched.finalUrl;
   } catch (fetchError) {
     const validationError = findValidationError(fetchError);
     if (validationError) {
@@ -458,7 +479,7 @@ async function fetchOpenGraphData(
       throw new Error('Failed to parse Open Graph data');
     }
 
-    return { data: result, validatedUrl };
+    return { data: result, finalUrl };
   } catch (parseError) {
     throw new PreviewGeneratorError(
       ErrorType.FETCH_ERROR,
@@ -476,86 +497,89 @@ function parseMetadata(ogData: Record<string, unknown>, url: string): ExtractedM
 
   // Extract title (prioritize OG title, then Twitter, then HTML title)
   const title =
-    (ogData.ogTitle as string) ||
-    (ogData.twitterTitle as string) ||
-    (ogData.dcTitle as string) ||
-    (ogData.title as string) ||
+    firstCleanText(ogData.ogTitle, ogData.twitterTitle, ogData.dcTitle, ogData.title) ||
     urlObj.hostname;
 
   // Extract description
-  const description =
-    (ogData.ogDescription as string) ||
-    (ogData.twitterDescription as string) ||
-    (ogData.dcDescription as string) ||
-    (ogData.description as string) ||
-    '';
+  const description = firstCleanText(
+    ogData.ogDescription,
+    ogData.twitterDescription,
+    ogData.dcDescription,
+    ogData.description
+  );
 
   // Extract image URL (prioritize OG image, then Twitter image)
-  let image = extractImageUrlFromData(ogData.ogImage) || extractImageUrlFromData(ogData.twitterImage);
-
-  // Ensure image URL is absolute
-  if (image && !image.startsWith('http')) {
-    try {
-      image = new URL(image, url).toString();
-    } catch {
-      image = undefined;
-    }
-  }
+  const image =
+    resolveHttpUrl(extractImageUrlFromData(ogData.ogImage), url) ??
+    resolveHttpUrl(extractImageUrlFromData(ogData.twitterImage), url);
 
   // Extract site name
   const siteName =
-    (ogData.ogSiteName as string) ||
-    (ogData.twitterSite as string) ||
-    (ogData.applicationName as string) ||
-    urlObj.hostname.replace('www.', '');
+    firstCleanText(ogData.ogSiteName, ogData.twitterSite, ogData.applicationName) ||
+    stripLeadingWww(urlObj.hostname);
 
   // Extract favicon
-  let favicon: string | undefined;
-  if (ogData.favicon) {
-    favicon = ogData.favicon as string;
-    if (favicon && !favicon.startsWith('http')) {
-      try {
-        const faviconUrl = new URL(favicon, url);
-        favicon = faviconUrl.toString();
-      } catch {
-        // Try default favicon path
-        favicon = `${urlObj.protocol}//${urlObj.hostname}/favicon.ico`;
-      }
-    }
-  } else {
-    // Default favicon path
-    favicon = `${urlObj.protocol}//${urlObj.hostname}/favicon.ico`;
-  }
+  const favicon = resolveHttpUrl(firstString(ogData.favicon), url) || getDefaultFaviconUrl(url);
 
   // Extract author
-  const author =
-    (ogData.author as string) ||
-    (ogData.dcCreator as string) ||
-    (ogData.twitterCreator as string) ||
-    (ogData.articleAuthor as string);
+  const author = firstCleanText(
+    ogData.author,
+    ogData.dcCreator,
+    ogData.twitterCreator,
+    ogData.articleAuthor
+  );
 
   // Extract published date
-  const publishedDate =
-    (ogData.ogArticlePublishedTime as string) ||
-    (ogData.articlePublishedTime as string) ||
-    (ogData.dcDate as string) ||
-    (ogData.publishedTime as string);
+  const publishedDate = firstCleanText(
+    ogData.ogArticlePublishedTime,
+    ogData.articlePublishedTime,
+    ogData.dcDate,
+    ogData.publishedTime
+  );
 
   // Extract locale
-  const locale = (ogData.ogLocale as string) || (ogData.inLanguage as string) || 'en_US';
+  const locale = firstCleanText(ogData.ogLocale, ogData.inLanguage) || 'en_US';
 
   return {
-    title: cleanText(title),
-    description: description ? cleanText(description) : undefined,
+    title,
+    description,
     image,
-    siteName: siteName ? cleanText(siteName) : undefined,
+    siteName,
     favicon,
-    author: author ? cleanText(author) : undefined,
-    publishedDate: publishedDate ? cleanText(publishedDate) : undefined,
+    author,
+    publishedDate,
     url,
     domain: urlObj.hostname,
-    locale: cleanText(locale),
+    locale,
   };
+}
+
+function firstString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.find(
+      (item): item is string => typeof item === 'string' && item.trim().length > 0
+    );
+  }
+  return undefined;
+}
+
+function firstCleanText(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const candidates = Array.isArray(value) ? value : [value];
+    for (const candidate of candidates) {
+      if (typeof candidate !== 'string') {
+        continue;
+      }
+      const cleaned = cleanText(candidate);
+      if (cleaned) {
+        return cleaned;
+      }
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -679,8 +703,8 @@ export function applyFallbacks(
     title: metadata.title || urlObj.hostname,
     description: metadata.description,
     image: metadata.image,
-    siteName: metadata.siteName || urlObj.hostname.replace('www.', ''),
-    favicon: metadata.favicon || `${urlObj.protocol}//${urlObj.hostname}/favicon.ico`,
+    siteName: metadata.siteName || stripLeadingWww(urlObj.hostname),
+    favicon: metadata.favicon || getDefaultFaviconUrl(url),
     author: metadata.author,
     publishedDate: metadata.publishedDate,
     url: metadata.url || url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,10 @@ import { createFallbackImageWithDetails, DEFAULT_DIMENSIONS } from './core/image
 import { templates } from './templates/registry';
 import {
   validateDimensions,
+  getDefaultFaviconUrl,
   sanitizeOptions,
   sanitizeControlChars,
+  stripLeadingWww,
   validateUrlInput,
 } from './utils/validators';
 import { initializeSharpSecurity } from './utils/image-security';
@@ -138,10 +140,10 @@ function normalizeMetadataInput(metadata: PreviewMetadataInput): ExtractedMetada
     image: metadata.image ? validateUrlInput(metadata.image) : undefined,
     siteName:
       normalizeOptionalMetadataText(metadata.siteName, 'metadata.siteName') ||
-      urlObj.hostname.replace('www.', ''),
+      stripLeadingWww(urlObj.hostname),
     favicon: metadata.favicon
       ? validateUrlInput(metadata.favicon)
-      : `${urlObj.protocol}//${urlObj.hostname}/favicon.ico`,
+      : getDefaultFaviconUrl(url),
     author: normalizeOptionalMetadataText(metadata.author, 'metadata.author'),
     publishedDate: normalizeOptionalMetadataText(metadata.publishedDate, 'metadata.publishedDate'),
     url,

--- a/src/utils/validators/url.ts
+++ b/src/utils/validators/url.ts
@@ -10,6 +10,38 @@ import {
 } from '../../constants/security';
 import { sanitizeControlChars } from './text';
 
+/** Resolve caller or page-provided URL text against a page URL and allow HTTP(S) only. */
+export function resolveHttpUrl(value: unknown, baseUrl: string): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const candidate = value.trim();
+  if (candidate.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const resolved = new URL(candidate, baseUrl);
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+      return undefined;
+    }
+    return resolved.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Build the conventional root favicon URL without dropping a non-default port. */
+export function getDefaultFaviconUrl(pageUrl: string): string {
+  return new URL('/favicon.ico', pageUrl).toString();
+}
+
+/** Remove only the conventional leading www. host label. */
+export function stripLeadingWww(hostname: string): string {
+  return hostname.replace(/^www\./i, '');
+}
+
 /**
  * Comprehensive URL validation with security checks.
  */
@@ -127,4 +159,3 @@ function isSafeUrlInput(url: string): boolean {
 
   return true;
 }
-

--- a/src/utils/validators/url.ts
+++ b/src/utils/validators/url.ts
@@ -34,7 +34,10 @@ export function resolveHttpUrl(value: unknown, baseUrl: string): string | undefi
 
 /** Build the conventional root favicon URL without dropping a non-default port. */
 export function getDefaultFaviconUrl(pageUrl: string): string {
-  return new URL('/favicon.ico', pageUrl).toString();
+  const faviconUrl = new URL('/favicon.ico', pageUrl);
+  faviconUrl.username = '';
+  faviconUrl.password = '';
+  return faviconUrl.toString();
 }
 
 /** Remove only the conventional leading www. host label. */

--- a/test/integration/end-to-end.test.ts
+++ b/test/integration/end-to-end.test.ts
@@ -720,6 +720,21 @@ describe('End-to-End Integration Tests', () => {
       expect(mockedOgs).not.toHaveBeenCalled();
     });
 
+    it('should preserve ports and internal www labels in direct metadata defaults', async () => {
+      const result = await generatePreviewFromMetadataWithDetails(
+        {
+          title: 'Direct metadata URL defaults',
+          url: 'https://blog.www.example.com:8443/posts/direct',
+        },
+        { template: 'article', width: 320, height: 168 }
+      );
+
+      expect(result.metadata).toMatchObject({
+        siteName: 'blog.www.example.com',
+        favicon: 'https://blog.www.example.com:8443/favicon.ico',
+      });
+    });
+
     it('should fetch direct metadata image without scraping page metadata', async () => {
       const pngImageBuffer = Buffer.from(
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -445,8 +445,8 @@ describe('Metadata Extractor', () => {
       expect(result.locale).toBe('en_US');
     });
 
-    it('should preserve ports and internal www labels in fallback metadata', () => {
-      const url = 'https://blog.www.example.com:8443/page';
+    it('should preserve ports and internal www labels without leaking credentials', () => {
+      const url = 'https://user:token@blog.www.example.com:8443/page';
 
       const result = applyFallbacks({}, url);
 

--- a/test/unit/metadata-extractor.test.ts
+++ b/test/unit/metadata-extractor.test.ts
@@ -155,6 +155,112 @@ describe('Metadata Extractor', () => {
       expect(result.favicon).toBe('https://minimal.com/favicon.ico');
     });
 
+    it('should resolve metadata against the last validated redirect URL', async () => {
+      const testUrl = 'https://origin.example/start';
+
+      mockedAxios.get.mockImplementationOnce(async (_url, config) => {
+        config?.beforeRedirect?.(
+          {
+            protocol: 'https:',
+            hostname: 'intermediate.example',
+            path: '/step',
+            href: 'https://intermediate.example/step',
+          },
+          { headers: {}, statusCode: 302 }
+        );
+        config?.beforeRedirect?.(
+          {
+            protocol: 'https:',
+            hostname: 'www.redirected.example',
+            port: '8443',
+            path: '/articles/2026/story.html?ref=home',
+            href: 'https://www.redirected.example:8443/articles/2026/story.html?ref=home',
+          },
+          { headers: {}, statusCode: 302 }
+        );
+        return { data: mockHtmlMinimal };
+      });
+      mockedOgs.mockResolvedValueOnce({
+        error: false,
+        result: {
+          ogTitle: 'Redirected article',
+          ogImage: [{ url: '../assets/card.jpg' }],
+          favicon: './favicon.svg',
+        },
+        html: mockHtmlMinimal,
+        response: {} as any,
+      });
+
+      const result = await extractMetadata(testUrl);
+
+      expect(result).toMatchObject({
+        title: 'Redirected article',
+        image: 'https://www.redirected.example:8443/articles/assets/card.jpg',
+        siteName: 'redirected.example',
+        favicon: 'https://www.redirected.example:8443/articles/2026/favicon.svg',
+        url: 'https://www.redirected.example:8443/articles/2026/story.html?ref=home',
+        domain: 'www.redirected.example',
+      });
+    });
+
+    it('should ignore non-string OG text and use the next valid value', async () => {
+      const testUrl = 'https://typed-metadata.example/page';
+
+      mockedAxios.get.mockResolvedValueOnce({ data: mockHtmlMinimal });
+      mockedOgs.mockResolvedValueOnce({
+        error: false,
+        result: {
+          ogTitle: { value: 'unsafe title shape' },
+          twitterTitle: ['  Safe title  '],
+          ogDescription: 42,
+          twitterDescription: ['Safe\n description'],
+          ogSiteName: {},
+          applicationName: ['Safe Site'],
+          favicon: { href: '/favicon.ico' },
+          author: {},
+          dcCreator: ['Safe Author'],
+          ogArticlePublishedTime: 42,
+          articlePublishedTime: ['2026-07-14'],
+          ogLocale: {},
+          inLanguage: ['ko_KR'],
+        } as any,
+        html: mockHtmlMinimal,
+        response: {} as any,
+      });
+
+      const result = await extractMetadata(testUrl);
+
+      expect(result).toMatchObject({
+        title: 'Safe title',
+        description: 'Safe description',
+        siteName: 'Safe Site',
+        favicon: 'https://typed-metadata.example/favicon.ico',
+        author: 'Safe Author',
+        publishedDate: '2026-07-14',
+        locale: 'ko_KR',
+      });
+    });
+
+    it('should use a valid Twitter image when the OG image URL is unsupported', async () => {
+      const testUrl = 'https://image-fallback.example/page';
+
+      mockedAxios.get.mockResolvedValueOnce({ data: mockHtmlMinimal });
+      mockedOgs.mockResolvedValueOnce({
+        error: false,
+        result: {
+          ogTitle: 'Image fallback',
+          ogImage: [{ url: 'data:image/png;base64,unsafe' }],
+          twitterImage: [{ url: '//cdn.example/twitter-card.jpg' }],
+        },
+        html: mockHtmlMinimal,
+        response: {} as any,
+      });
+
+      const result = await extractMetadata(testUrl);
+
+      expect(result.image).toBe('https://cdn.example/twitter-card.jpg');
+    });
+
     it('should truncate cleaned remote metadata text to 10,000 characters', async () => {
       const testUrl = 'https://long-metadata.example';
 
@@ -337,6 +443,15 @@ describe('Metadata Extractor', () => {
       expect(result.url).toBe(url);
       expect(result.domain).toBe('test.com');
       expect(result.locale).toBe('en_US');
+    });
+
+    it('should preserve ports and internal www labels in fallback metadata', () => {
+      const url = 'https://blog.www.example.com:8443/page';
+
+      const result = applyFallbacks({}, url);
+
+      expect(result.siteName).toBe('blog.www.example.com');
+      expect(result.favicon).toBe('https://blog.www.example.com:8443/favicon.ico');
     });
   });
 

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -6,11 +6,50 @@ import {
   validateColor,
   validateDimensions,
   createTransparentCanvas,
+  getDefaultFaviconUrl,
+  resolveHttpUrl,
   sanitizeOptions,
+  stripLeadingWww,
 } from '../../../src/utils/validators';
 import { PreviewGeneratorError, ErrorType, PreviewOptions } from '../../../src/types';
 
 describe('Validators', () => {
+  describe('URL helpers', () => {
+    test('should resolve relative and canonical HTTP(S) URLs', () => {
+      const baseUrl = 'https://origin.example/articles/2026/story';
+
+      expect(resolveHttpUrl('../assets/card.jpg', baseUrl)).toBe(
+        'https://origin.example/articles/assets/card.jpg'
+      );
+      expect(resolveHttpUrl('//cdn.example/card.jpg', baseUrl)).toBe(
+        'https://cdn.example/card.jpg'
+      );
+      expect(resolveHttpUrl('HTTPS://CDN.EXAMPLE/card.jpg', baseUrl)).toBe(
+        'https://cdn.example/card.jpg'
+      );
+    });
+
+    test.each(['httpsx://cdn.example/card.jpg', 'javascript:alert(1)', 'data:image/png,x', ''])(
+      'should reject non-HTTP(S) URL %j',
+      value => {
+        expect(resolveHttpUrl(value, 'https://origin.example/page')).toBeUndefined();
+      }
+    );
+
+    test('should preserve non-default ports in the default favicon URL', () => {
+      expect(getDefaultFaviconUrl('https://example.com:8443/articles/page')).toBe(
+        'https://example.com:8443/favicon.ico'
+      );
+    });
+
+    test('should strip only a leading www. label', () => {
+      expect(stripLeadingWww('www.example.com')).toBe('example.com');
+      expect(stripLeadingWww('WWW.example.com')).toBe('example.com');
+      expect(stripLeadingWww('blog.www.example.com')).toBe('blog.www.example.com');
+      expect(stripLeadingWww('notwww.example.com')).toBe('notwww.example.com');
+    });
+  });
+
   describe('validateColor', () => {
     describe('Valid colors', () => {
       test('should accept valid hex colors', () => {

--- a/test/unit/utils/validators.test.ts
+++ b/test/unit/utils/validators.test.ts
@@ -42,6 +42,12 @@ describe('Validators', () => {
       );
     });
 
+    test('should drop credentials from the default favicon URL', () => {
+      expect(getDefaultFaviconUrl('https://user:token@example.com:8443/articles/page')).toBe(
+        'https://example.com:8443/favicon.ico'
+      );
+    });
+
     test('should strip only a leading www. label', () => {
       expect(stripLeadingWww('www.example.com')).toBe('example.com');
       expect(stripLeadingWww('WWW.example.com')).toBe('example.com');


### PR DESCRIPTION
## Summary
- track the last validated redirect URL and use it as the metadata base
- resolve image and favicon URLs with HTTP(S)-only URL parsing
- preserve non-default favicon ports and strip only a leading `www.`
- ignore malformed non-string OG fields and retain valid fallback candidates

## Root cause
Metadata parsing retained the initial request URL after redirects and used string-prefix checks for asset URLs. That could resolve relative assets against the wrong origin or path and drop ports or valid fallback metadata.

## Validation
- `pnpm test` (31 files, 649 tests)
- `pnpm run lint`
- `pnpm run build`
- `pnpm run verify:package`
- adversarial pre-commit review (one image fallback issue found, fixed, and re-reviewed clean)

The real-URL HTTP test was intentionally not run because it is excluded from ordinary repository validation.