### PR TITLE
fix(deps): update DOMPurify to 3.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "file-type": "^22.0.1",
     "jsdom": "^29.1.1",
     "open-graph-scraper": "^6.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^1.11.0
         version: 1.18.1
       dompurify:
-        specifier: ^3.4.11
-        version: 3.4.11
+        specifier: ^3.4.12
+        version: 3.4.12
       file-type:
         specifier: ^22.0.1
         version: 22.0.1
@@ -913,8 +913,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2303,7 +2303,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary
- update DOMPurify from 3.4.11 to 3.4.12
- resolve GHSA-c2j3-45gr-mqc4 without bundling unrelated major upgrades

## Validation
- Node 24: lint, 650 tests, build
- Node 22.22.1: 650 tests, build
- git diff --check
- read-only adversarial review: no actionable findings