### PR TITLE
fix(deps): remediate dependency security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "file-type": "^22.0.1",
     "jsdom": "^29.1.1",
     "open-graph-scraper": "^6.10.0",
@@ -60,11 +60,13 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion@>=5.0.0 <5.0.8": "5.0.8",
+      "brace-expansion@>=5.0.0 <5.0.9": "5.0.9",
       "esbuild@>=0.27.3 <0.28.1": "0.28.1",
       "flatted@<=3.4.1": "3.4.2",
+      "nanoid@<3.3.17": "3.3.17",
       "picomatch@>=4.0.0 <4.0.4": "4.0.5",
-      "postcss@<=8.5.17": "8.5.18"
+      "postcss@<=8.5.17": "8.5.18",
+      "undici@>=7.0.0 <7.29.0": "7.29.0"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
+  brace-expansion@>=5.0.0 <5.0.9: 5.0.9
   esbuild@>=0.27.3 <0.28.1: 0.28.1
   flatted@<=3.4.1: 3.4.2
+  nanoid@<3.3.17: 3.3.17
   picomatch@>=4.0.0 <4.0.4: 4.0.5
   postcss@<=8.5.17: 8.5.18
+  undici@>=7.0.0 <7.29.0: 7.29.0
 
 importers:
 
@@ -19,8 +21,8 @@ importers:
         specifier: ^1.11.0
         version: 1.18.1
       dompurify:
-        specifier: ^3.4.12
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
       file-type:
         specifier: ^22.0.1
         version: 22.0.1
@@ -903,8 +905,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -1300,8 +1302,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1506,8 +1508,8 @@ packages:
   undici-types@7.28.0:
     resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   uri-js@4.4.1:
@@ -2311,7 +2313,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   combined-stream@1.0.8:
@@ -2372,7 +2374,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -2686,7 +2688,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -2795,7 +2797,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -2810,7 +2812,7 @@ snapshots:
       chardet: 2.2.0
       cheerio: 1.2.0
       iconv-lite: 0.7.3
-      undici: 7.28.0
+      undici: 7.29.0
 
   optionator@0.9.4:
     dependencies:
@@ -2858,7 +2860,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3008,7 +3010,7 @@ snapshots:
 
   undici-types@7.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- update DOMPurify to 3.4.13
- override undici to 7.29.0 for the active high and moderate security advisories
- update brace-expansion and nanoid to patched releases
- avoid the incompatible TypeScript 7 and jsdom 30 updates in Dependabot PR #91

## Validation

- Node 24: pnpm install --frozen-lockfile
- Node 24: pnpm lint
- Node 24: pnpm test (650 tests passed)
- Node 24: pnpm build
- Node 24: pnpm verify:package
- Node 24: pnpm audit (0 vulnerabilities)
- Node 22.22.1: pnpm test (650 tests passed)
- Node 22.22.1: pnpm build