### PR TITLE
chore(deps): prevent incompatible grouped major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       dependencies:
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
- restrict the broad npm dependency group to minor and patch updates
- ignore automatic TypeScript semver-major updates
- prevent recurrence of the incompatible TypeScript 7 update in #98

## Validation
- parsed .github/dependabot.yml and asserted the configured update-types and ignore rule
- git diff --check