### PR TITLE
chore(deps): defer jsdom 30 until Node floor update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
       - dependency-name: typescript
         update-types:
           - version-update:semver-major
+      - dependency-name: jsdom
+        update-types:
+          - version-update:semver-major
+      - dependency-name: '@types/jsdom'
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
- ignore semver-major updates for jsdom and @types/jsdom
- keep jsdom 29 while the package supports Node ^22.13.0 || >=24.0.0
- prevent regeneration of #102, because jsdom 30.0.1 requires Node ^22.22.2 || ^24.15.0 || >=26.0.0

## Validation
- parsed .github/dependabot.yml and asserted both ignore entries
- git diff --check