### PR TITLE
chore: release v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanggo/social-preview",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Generate beautiful social media preview images from any URL",
   "packageManager": "pnpm@10.11.0",
   "main": "dist/index.js",


### PR DESCRIPTION
## What changed

- bump `@nanggo/social-preview` from `0.5.0` to `0.5.1`
- keep this release-prep change limited to `package.json`

## Why

Publish the corrected and expanded English/Korean README from PR #106 to npm. npm README content is captured from the package tarball and cannot update the existing `0.5.0` in place.

## Validation

- `pnpm run verify:release -- --tag v0.5.1`
- `pnpm audit --prod` (0 advisories)
- `pnpm run verify:dependencies`
- `pnpm run lint`
- `pnpm run build`
- `pnpm test` (702 passed)
- `pnpm run verify:package`

After merge, an annotated `v0.5.1` tag will trigger the trusted-publishing workflow. The excluded real-URL integration test was not run.