### PR TITLE
docs: position package around URL-to-social-card

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 **English** | [한국어](https://github.com/nanggo/social-preview-generator/blob/master/docs/README.ko.md)
 
-Generate production-ready Open Graph and social preview images in server-side Node.js. Start from a
-public URL or render metadata you already have.
+Turn a public HTTP(S) URL into a secure, consistent social preview JPEG—no JSX or Next.js route
+required.
+
+`generatePreview(url)` fetches Open Graph and Twitter Card metadata, blocks private and reserved
+network targets, applies a built-in template, and returns a JPEG `Buffer`.
 
 [![npm version](https://img.shields.io/npm/v/@nanggo/social-preview.svg)](https://www.npmjs.com/package/@nanggo/social-preview)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -11,13 +14,23 @@ public URL or render metadata you already have.
 
 ## Highlights
 
-- Extract Open Graph and Twitter Card metadata from HTTP(S) URLs
-- Render supplied metadata without fetching the page itself
+- Convert a public URL to a JPEG `Buffer` in one call
+- Extract Open Graph and Twitter Card metadata automatically
+- Guard outbound fetches against private, loopback, reserved, and mixed-DNS targets
+- Run in server-side Node.js without React, JSX, a browser, or an image API route
+- Render supplied metadata directly when a URL fetch is unnecessary
 - Choose from `modern`, `classic`, `minimal`, and `article` templates
-- Generate JPEG images with configurable dimensions and quality; the default is 1200×630
 - Use CommonJS, ESM, or TypeScript
 - Render Korean text with server-side font fallbacks
-- Apply URL, SSRF, SVG, input-size, and memory safeguards before rendering
+
+## When this package fits
+
+| Good fit                                                                                      | Consider another tool when                                    |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Link directories, bookmark services, curation tools, and other products that start with a URL | You already have all data and want free-form React/JSX design |
+| CMS, static-site, or batch jobs that write preview files ahead of time                        | You need a browser or Edge runtime                            |
+| Node.js services that accept public URLs and need guarded network defaults                    | You need JavaScript-rendered pages from a headless browser    |
+| Workflows that need a `Buffer` or file instead of an HTTP image response                      | You want to build and maintain a custom image route           |
 
 ## Requirements
 
@@ -30,7 +43,7 @@ public URL or render metadata you already have.
 npm install @nanggo/social-preview
 ```
 
-## Quick start
+## URL to JPEG in one call
 
 ```javascript
 const { writeFile } = require('node:fs/promises');
@@ -53,7 +66,7 @@ ESM named imports are also supported:
 import { generatePreview } from '@nanggo/social-preview';
 ```
 
-## Generate from known metadata
+## Secondary: render known metadata
 
 Use `generatePreviewFromMetadata` when your publishing or build pipeline already knows the title,
 canonical URL, description, and optional image.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -2,9 +2,11 @@
 
 [English](../README.md) | **한국어**
 
-서버용 Node.js 환경에서 바로 사용할 수 있는 Open Graph 및 소셜 미리보기 이미지를
-생성합니다. 공개 URL에서 메타데이터를 가져오거나, 이미 알고 있는 메타데이터를 직접
-렌더링할 수 있습니다.
+공개 HTTP(S) URL 하나를 안전하고 일관된 소셜 미리보기 JPEG로 변환합니다. JSX나 Next.js
+route가 필요하지 않습니다.
+
+`generatePreview(url)`가 Open Graph 및 Twitter Card 메타데이터를 가져오고 private 및
+reserved network target을 차단한 뒤, 내장 템플릿을 적용해 JPEG `Buffer`를 반환합니다.
 
 [![npm version](https://img.shields.io/npm/v/@nanggo/social-preview.svg)](https://www.npmjs.com/package/@nanggo/social-preview)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -12,13 +14,23 @@
 
 ## 주요 특징
 
-- HTTP(S) URL에서 Open Graph 및 Twitter Card 메타데이터 추출
-- 페이지 자체를 요청하지 않고 전달받은 메타데이터 렌더링
+- 공개 URL을 한 번의 호출로 JPEG `Buffer`로 변환
+- Open Graph 및 Twitter Card 메타데이터 자동 추출
+- private, loopback, reserved 및 mixed-DNS target으로 향하는 요청 차단
+- React, JSX, 브라우저 또는 이미지 API route 없이 서버용 Node.js에서 실행
+- URL 요청이 필요 없을 때 전달받은 메타데이터를 직접 렌더링
 - `modern`, `classic`, `minimal`, `article` 내장 템플릿 제공
-- 크기와 품질을 설정할 수 있는 JPEG 이미지 생성(기본 1200×630)
 - CommonJS, ESM, TypeScript 지원
 - 서버 글꼴 fallback을 사용한 한국어 텍스트 렌더링
-- 렌더링 전 URL, SSRF, SVG, 입력 크기 및 메모리 보호 적용
+
+## 이런 경우에 적합합니다
+
+| 적합한 경우                                                       | 다른 도구가 더 적합한 경우                                     |
+| ----------------------------------------------------------------- | -------------------------------------------------------------- |
+| URL에서 시작하는 링크 디렉터리, 북마크, 큐레이션 서비스           | 데이터가 이미 있고 React/JSX로 자유롭게 디자인하려는 경우      |
+| 미리보기 파일을 미리 생성하는 CMS, 정적 사이트 및 batch 작업      | 브라우저 또는 Edge runtime이 필요한 경우                       |
+| 공개 URL을 입력받고 안전한 network 기본값이 필요한 Node.js 서비스 | headless browser로 JavaScript 렌더링 페이지를 읽어야 하는 경우 |
+| HTTP 이미지 응답 대신 `Buffer` 또는 파일이 필요한 작업            | 사용자 지정 이미지 route를 직접 만들고 운영하려는 경우         |
 
 ## 요구사항
 
@@ -31,7 +43,7 @@
 npm install @nanggo/social-preview
 ```
 
-## 빠른 시작
+## URL 하나로 JPEG 생성
 
 ```javascript
 const { writeFile } = require('node:fs/promises');
@@ -54,7 +66,7 @@ ESM named import도 지원합니다.
 import { generatePreview } from '@nanggo/social-preview';
 ```
 
-## 알고 있는 메타데이터로 생성
+## 보조 기능: 알고 있는 메타데이터로 생성
 
 게시 또는 빌드 파이프라인에서 제목, canonical URL, 설명과 선택적 이미지 정보를 이미 알고
 있다면 `generatePreviewFromMetadata`를 사용합니다.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nanggo/social-preview",
   "version": "0.5.1",
-  "description": "Generate beautiful social media preview images from any URL",
+  "description": "Turn public URLs into secure social preview JPEGs with Node.js",
   "packageManager": "pnpm@10.11.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What changed

- lead with the one-call public URL to guarded JPEG Buffer workflow
- explain where the package is and is not a good fit
- make direct-metadata rendering explicitly secondary
- align the Korean README with the same positioning
- replace the broad npm description with a precise Node.js URL-to-social-card description

## Why

The previous copy described a generic OG image generator, which obscured the package's main reason to exist: fetching public URL metadata with built-in network safeguards and returning a ready-to-write JPEG without JSX or a Next.js image route.

## Validation

- `pnpm exec prettier --check README.md docs/README.ko.md package.json`
- JavaScript syntax parsing for all five examples in both READMEs
- `pnpm run build`
- `pnpm run verify:package`

The excluded real-URL integration test was not run.