### PR TITLE
chore: release v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanggo/social-preview",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Turn public URLs into secure social preview JPEGs with Node.js",
   "packageManager": "pnpm@10.11.0",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump the package version from 0.5.1 to 0.5.2
- publish the merged README positioning and package description update

## Verification
- `pnpm audit --prod`
- `pnpm run verify:dependencies`
- `pnpm test` (34 files, 702 tests)
- `pnpm run lint`
- `pnpm run build`
- `pnpm run verify:package`
- `pnpm run verify:release -- --tag v0.5.2`

This is a release-only PR. npm publishing remains tag-triggered after merge.